### PR TITLE
Correct autoreset_latch.v for tests/ & tests_ok/

### DIFF
--- a/tests/autoreset_latch.v
+++ b/tests/autoreset_latch.v
@@ -13,11 +13,6 @@ module device(
      if (!rstn) begin
 	state <= IDLE;
 	/*AUTORESET*/
-	// Beginning of autoreset for uninitialized flops
-	fail <= 1'h0;
-	pass <= 1'h0;
-	ready <= 1'h0;
-	// End of automatics
      end
      else begin
 	state <= next_state;
@@ -29,9 +24,6 @@ module device(
    always @* begin
       if (!ready) begin
 	 /*AUTORESET*/
-	 // Beginning of autoreset for uninitialized flops
-	 out0 = 8'h0;
-	 // End of automatics
       end
       else begin
 	 out0 = sel ? in1 : in0;
@@ -41,9 +33,6 @@ module device(
    always_comb begin
       next_state = state;
       /*AUTORESET*/
-      // Beginning of autoreset for uninitialized flops
-      out0 = 8'h0;
-      // End of automatics
       case (state)
 	IDLE :	begin
 	   // stuff ...
@@ -66,9 +55,6 @@ module device(
    always_latch begin
       if (!rstn) begin
 	 /*AUTORESET*/
-	 // Beginning of autoreset for uninitialized flops
-	 out0 = 8'h0;
-	 // End of automatics
       end
       else if (clk) begin
 	 Q <= D;

--- a/tests_ok/autoreset_latch.v
+++ b/tests_ok/autoreset_latch.v
@@ -43,8 +43,8 @@ module device(
       /*AUTORESET*/
       // Beginning of autoreset for uninitialized flops
       next_ready = 1'h0;
-      next_pass = 1'b0;
-      next_fail = 1'b0;
+      next_pass = 1'h0;
+      next_fail = 1'h0;
       // End of automatics
       case (state)
 	IDLE :	begin

--- a/tests_ok/autoreset_latch.v
+++ b/tests_ok/autoreset_latch.v
@@ -42,7 +42,9 @@ module device(
       next_state = state;
       /*AUTORESET*/
       // Beginning of autoreset for uninitialized flops
-      out0 = 8'h0;
+      next_ready = 1'h0;
+      next_pass = 1'b0;
+      next_fail = 1'b0;
       // End of automatics
       case (state)
 	IDLE :	begin
@@ -67,7 +69,7 @@ module device(
       if (!rstn) begin
 	 /*AUTORESET*/
 	 // Beginning of autoreset for uninitialized flops
-	 out0 = 8'h0;
+	 Q <= 8'h0;
 	 // End of automatics
       end
       else if (clk) begin


### PR DESCRIPTION
Following the format of other tests vs tests_ok files:
Correct tests/autoreset_latch.v to look before applying verilog-batch-auto
Correct tests_ok/autoreset_latch.v ot look after applying verilog-batch-auto