### PR TITLE
Virtual task/function/class indentation

### DIFF
--- a/tests/indent_function.v
+++ b/tests/indent_function.v
@@ -35,5 +35,16 @@ class pure_virt_func_class;
    endfunction // f
 endclass // pure_virt_func_class
 
-
-
+class base_test extends uvm_test;
+   `uvm_component_utils(base_test)
+   typedef virtual my_if my_vif_t;
+   // A function definition starting with the virtual keyword should not be
+   // detected as a declaration. This issue is seen when an attempt to indent
+   // each declaration is done (when the verilog-auto-lineup variable is set
+   // to 'declarations).
+   //   In other words, the "function" in "virtual function" below must not be
+   // aligned with "my_if" in the "typedef virtual my_if.." line above.
+   virtual function void start_of_simulation_phase(uvm_phase phase);
+      super.start_of_simulation_phase(phase);
+   endfunction : start_of_simulation_phase
+endclass : base_test

--- a/tests/indent_task.v
+++ b/tests/indent_task.v
@@ -77,3 +77,16 @@ class a;
    
 endclass // a
 
+class base_test extends uvm_test;
+   `uvm_component_utils(base_test)
+   typedef virtual my_if my_vif_t;
+   // A task definition starting with the virtual keyword should not be
+   // detected as a declaration. This issue is seen when an attempt to indent
+   // each declaration is done (when the verilog-auto-lineup variable is set
+   // to 'declarations).
+   //   In other words, the "task" in "virtual task" below must not be
+   // aligned with "my_if" in the "typedef virtual my_if.." line above.
+   virtual task run_phase(uvm_phase phase);
+      super.run_phase(phase);
+   endtask // run_phase
+endclass // base_test

--- a/tests_ok/indent_function.v
+++ b/tests_ok/indent_function.v
@@ -35,5 +35,16 @@ class pure_virt_func_class;
    endfunction // f
 endclass // pure_virt_func_class
 
-
-
+class base_test extends uvm_test;
+   `uvm_component_utils(base_test)
+   typedef virtual my_if my_vif_t;
+   // A function definition starting with the virtual keyword should not be
+   // detected as a declaration. This issue is seen when an attempt to indent
+   // each declaration is done (when the verilog-auto-lineup variable is set
+   // to 'declarations).
+   //   In other words, the "function" in "virtual function" below must not be
+   // aligned with "my_if" in the "typedef virtual my_if.." line above.
+   virtual function void start_of_simulation_phase(uvm_phase phase);
+      super.start_of_simulation_phase(phase);
+   endfunction : start_of_simulation_phase
+endclass : base_test

--- a/tests_ok/indent_task.v
+++ b/tests_ok/indent_task.v
@@ -77,3 +77,16 @@ class a;
    
 endclass // a
 
+class base_test extends uvm_test;
+   `uvm_component_utils(base_test)
+   typedef virtual my_if my_vif_t;
+   // A task definition starting with the virtual keyword should not be
+   // detected as a declaration. This issue is seen when an attempt to indent
+   // each declaration is done (when the verilog-auto-lineup variable is set
+   // to 'declarations).
+   //   In other words, the "task" in "virtual task" below must not be
+   // aligned with "my_if" in the "typedef virtual my_if.." line above.
+   virtual task run_phase(uvm_phase phase);
+      super.run_phase(phase);
+   endtask // run_phase
+endclass // base_test

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -6563,7 +6563,11 @@ Only look at a few lines to determine indent level."
       (and (or
 	    (eq type 'defun)
 	    (eq type 'block))
-	   (looking-at verilog-declaration-re))
+	   (looking-at verilog-declaration-re)
+           ;; Do not consider "virtual function", "virtual task", "virtual class"
+           ;; as declarations
+           (not (looking-at (concat verilog-declaration-re
+                                    "\\s-+\\(function\\|task\\|class\\)\\b"))))
       (verilog-indent-declaration ind))
 
      (;-- form feeds - ignored as bug in indent-line-to in < 24.5


### PR DESCRIPTION
- Virtual task/function/class definition lines should not be considered
  as declarations

**Test Bug?**
The new tests I add to verify this fix pass before and after fix when run using `make test`!

But if I have those test files open in a buffer and if I indent that region manually, the incorrect indentation is seen happening **before** the fix only.

This pull request is an attempt to fix http://www.veripool.org/issues/817-Verilog-mode-Wrong-alignment-on-virtual-keyword