### PR TITLE
Add INFO-DIR-SECTION

### DIFF
--- a/verilog.texinfo
+++ b/verilog.texinfo
@@ -4,6 +4,7 @@
 
 @ifinfo
 @format
+INFO-DIR-SECTION Emacs
 START-INFO-DIR-ENTRY
 * Verilog-mode: (verilog).	The Verilog Mode user guide.
 END-INFO-DIR-ENTRY


### PR DESCRIPTION
The "info-document-missing-dir-section" lintian error on Debian occurs, if there is not this INFO-DIR-SECTION. For more detail, see following page:

https://lintian.debian.org/tags/info-document-missing-dir-section.html