### PR TITLE
Fix indentation after "typedef class .."

### DIFF
--- a/tests/indent_virtual_class_following_typedef.sv
+++ b/tests/indent_virtual_class_following_typedef.sv
@@ -1,0 +1,4 @@
+// issue 1080 - Indentation of a virtual class definition after a typedef class line
+typedef class foo;
+    virtual class bar;
+        endclass : bar

--- a/tests_ok/indent_task_func_decl.sv
+++ b/tests_ok/indent_task_func_decl.sv
@@ -1,5 +1,5 @@
 typedef class burst_drv;
-   
+
 class burst_drv extends vmm_xactor;
    
    int EXECUTING;
@@ -87,4 +87,4 @@ class burst_drv extends vmm_xactor;
       this.rx_dma.start();
    endtask // static
 endclass : burst_drv
-   
+

--- a/tests_ok/indent_virtual_class_following_typedef.sv
+++ b/tests_ok/indent_virtual_class_following_typedef.sv
@@ -1,0 +1,4 @@
+// issue 1080 - Indentation of a virtual class definition after a typedef class line
+typedef class foo;
+virtual class bar;
+endclass : bar

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -5790,11 +5790,9 @@ Return a list of two elements: (INDENT-TYPE INDENT-LEVEL)."
                        (goto-char here) ; or is clocking, starts a new block
                        (throw 'nesting 'block)))))
 
-             ;; need to consider typedef struct here...
              ((looking-at "\\<class\\|struct\\|function\\|task\\>")
               ;; *sigh* These words have an optional prefix:
               ;; extern {virtual|protected}? function a();
-              ;; typedef class foo;
               ;; and we don't want to confuse this with
               ;; function a();
               ;; property
@@ -5804,7 +5802,11 @@ Return a list of two elements: (INDENT-TYPE INDENT-LEVEL)."
               (cond
                ((looking-at verilog-dpi-import-export-re)
                 (throw 'continue 'foo))
-               ((looking-at "\\<pure\\>\\s-+\\<virtual\\>\\s-+\\(?:\\<\\(local\\|protected\\|static\\)\\>\\s-+\\)?\\<\\(function\\|task\\)\\>\\s-+")
+               ((or
+                 (looking-at "\\<pure\\>\\s-+\\<virtual\\>\\s-+\\(?:\\<\\(local\\|protected\\|static\\)\\>\\s-+\\)?\\<\\(function\\|task\\)\\>\\s-+")
+                 ;; Do not throw 'defun for class typedefs like
+                 ;;   typedef class foo;
+                 (looking-at "\\<typedef\\>\\s-+\\(?:\\<virtual\\>\\s-+\\)?\\<class\\>\\s-+"))
                 (throw 'nesting 'statement))
                ((looking-at verilog-beg-block-re-ordered)
                 (throw 'nesting 'block))


### PR DESCRIPTION
https://www.veripool.org/issues/1080-Verilog-mode-Indentation-of-a-virtual-class-definition-after-a-typedef-class-line