### PR TITLE
Fix extra space by verilog pretty expr

### DIFF
--- a/tests/indent_lineup_mode_all.v
+++ b/tests/indent_lineup_mode_all.v
@@ -10,6 +10,24 @@ module test (pci_ack, reg_wr, reg_sel, clk,  rst);
       x <= y;
       longish <= alsolongish;
    end
+   // Only blocking assignments
+   initial begin
+      lorem = 0;
+      ip = 1;
+      sum = 2;
+   end
+   // Only non-blocking assignments
+   initial begin
+      dolor <= 0;
+      sit <= 1;
+      amet <= 2;
+   end
+   // Mix of blocking and non-blocking assignments
+   initial begin
+      consectetur = 0;
+      adipiscing <= 1;
+      elit <= 2;
+   end
 
 endmodule
 

--- a/tests_ok/autoarg_quote_cmt.v
+++ b/tests_ok/autoarg_quote_cmt.v
@@ -4,7 +4,7 @@ module f (/*AUTOARG*/
           x
           );
    
-   always @* r  = "test/*";
+   always @* r = "test/*";
    
    input x;
    

--- a/tests_ok/autoarg_string_bug259.v
+++ b/tests_ok/autoarg_string_bug259.v
@@ -16,7 +16,7 @@ module bug_minimal
    task force_value_to_1;
       begin
          $display("Enable test module checking ...");
-         force `value  = 1'b1;
+         force `value = 1'b1;
       end
    endtask
    
@@ -24,7 +24,7 @@ module bug_minimal
    task force_value_to_0;
       begin
          $display("Disable test module checking ...");
-         force `value  = 1'b0;
+         force `value = 1'b0;
       end
    endtask
    

--- a/tests_ok/autoascii_myers.v
+++ b/tests_ok/autoascii_myers.v
@@ -12,9 +12,9 @@ module testit;
    
    //== State enumeration
    parameter [2:0] // synopsys enum state_info
-     SM_IDLE   = 3'b000,
-     SM_SEND   = 3'b001,
-     SM_WAIT1  = 3'b010;
+     SM_IDLE  = 3'b000,
+     SM_SEND  = 3'b001,
+     SM_WAIT1 = 3'b010;
    //== State variables
    reg [2:0]  /* synopsys enum state_info */
               state_r; /* synopsys state_vector state_r */
@@ -28,22 +28,22 @@ module testit;
    reg [39:0] _stateascii_r;            // Decode of state_r
    always @(state_r) begin
       case ({state_r})
-        SM_IDLE:  _stateascii_r  = "idle ";
-        SM_SEND:  _stateascii_r  = "send ";
-        SM_WAIT1: _stateascii_r  = "wait1";
-        default:  _stateascii_r  = "%Erro";
+        SM_IDLE:  _stateascii_r = "idle ";
+        SM_SEND:  _stateascii_r = "send ";
+        SM_WAIT1: _stateascii_r = "wait1";
+        default:  _stateascii_r = "%Erro";
       endcase
    end
    // End of automatics
    
    initial begin
-      clk        = 0;
-      a_i        = 0;
-      b_i        = 0;
-      rst_n      = 0;
-      #20 rst_n  = 1;
+      clk       = 0;
+      a_i       = 0;
+      b_i       = 0;
+      rst_n     = 0;
+      #20 rst_n = 1;
    end
-   always #5 clk  = ~clk;
+   always #5 clk = ~clk;
    
    always @(posedge clk or rst_n) begin
       if (~rst_n) begin
@@ -60,7 +60,7 @@ module testit;
    
    task set_a_i;
       begin
-         a_i  = shreg[0];
+         a_i = shreg[0];
       end
    endtask // set_a_i
    

--- a/tests_ok/autoascii_peltan.v
+++ b/tests_ok/autoascii_peltan.v
@@ -8,7 +8,7 @@ module autoascii_peltan
    
    // Duplicate of what's in _inc
    localparam [3:0] /* synopsys enum xstate */
-     state0  = 4'h0;
+     state0 = 4'h0;
    
    wire [3:0] /* synopsys enum xstate */
               xstate;
@@ -20,9 +20,9 @@ module autoascii_peltan
    reg [47:0] v_xstate;         // Decode of xstate
    always @(xstate) begin
       case ({xstate})
-        state0:   v_xstate  = "state0";
-        state1:   v_xstate  = "state1";
-        default:  v_xstate  = "%Error";
+        state0:   v_xstate = "state0";
+        state1:   v_xstate = "state1";
+        default:  v_xstate = "%Error";
       endcase
    end
    // End of automatics

--- a/tests_ok/autoascii_peltan_inc.v
+++ b/tests_ok/autoascii_peltan_inc.v
@@ -1,3 +1,3 @@
 localparam [3:0] /* synopsys enum xstate */
-  state0  = 4'h0,
-  state1  = 4'h1;
+  state0 = 4'h0,
+  state1 = 4'h1;

--- a/tests_ok/autoasciienum_auto.v
+++ b/tests_ok/autoasciienum_auto.v
@@ -6,23 +6,23 @@ module autoasciienum_auto();
    reg [2:0] /* auto enum sm_ps2 */ sm_ps2;
    
    localparam [2:0] // auto enum sm_psm
-     PSM_IDL  = 0,
-     PSM_RST  = 6,
-     PSM_ZOT  = 7;
+     PSM_IDL = 0,
+     PSM_RST = 6,
+     PSM_ZOT = 7;
    
    localparam [2:0] // auto enum sm_ps2
-     PS2_IDL  = 0,
-     PS2_FOO  = 1;
+     PS2_IDL = 0,
+     PS2_FOO = 1;
    
    /*AUTOASCIIENUM("sm_psm", "_sm_psm__ascii", "_")*/
    // Beginning of automatic ASCII enum decoding
    reg [47:0] _sm_psm__ascii;           // Decode of sm_psm
    always @(sm_psm) begin
       case ({sm_psm})
-        PSM_IDL:  _sm_psm__ascii  = "psmidl";
-        PSM_RST:  _sm_psm__ascii  = "psmrst";
-        PSM_ZOT:  _sm_psm__ascii  = "psmzot";
-        default:  _sm_psm__ascii  = "%Error";
+        PSM_IDL:  _sm_psm__ascii = "psmidl";
+        PSM_RST:  _sm_psm__ascii = "psmrst";
+        PSM_ZOT:  _sm_psm__ascii = "psmzot";
+        default:  _sm_psm__ascii = "%Error";
       endcase
    end
    // End of automatics
@@ -31,9 +31,9 @@ module autoasciienum_auto();
    reg [47:0] _sm_ps2__ascii;           // Decode of sm_ps2
    always @(sm_ps2) begin
       case ({sm_ps2})
-        PS2_IDL:  _sm_ps2__ascii  = "ps2idl";
-        PS2_FOO:  _sm_ps2__ascii  = "ps2foo";
-        default:  _sm_ps2__ascii  = "%Error";
+        PS2_IDL:  _sm_ps2__ascii = "ps2idl";
+        PS2_FOO:  _sm_ps2__ascii = "ps2foo";
+        default:  _sm_ps2__ascii = "%Error";
       endcase
    end
    // End of automatics

--- a/tests_ok/autoasciienum_ex.v
+++ b/tests_ok/autoasciienum_ex.v
@@ -8,8 +8,8 @@ module sm (/*AUTOARG*/
    
    //== State enumeration
    parameter [2:0] // synopsys enum state_info
-     SM_IDLE  = 3'b000,
-     SM_ACT   = 3'b010;
+     SM_IDLE = 3'b000,
+     SM_ACT  = 3'b010;
    //== State variables
    reg [2:0]  /* synopsys enum state_info */
               state_r; /* synopsys state_vector state_r */
@@ -23,9 +23,9 @@ module sm (/*AUTOARG*/
    reg [31:0] _stateascii_r;            // Decode of state_r
    always @(state_r) begin
       case ({state_r})
-        SM_IDLE:  _stateascii_r  = "idle";
-        SM_ACT:   _stateascii_r  = "act ";
-        default:  _stateascii_r  = "%Err";
+        SM_IDLE:  _stateascii_r = "idle";
+        SM_ACT:   _stateascii_r = "act ";
+        default:  _stateascii_r = "%Err";
       endcase
    end
    // End of automatics

--- a/tests_ok/autoasciienum_frominc.v
+++ b/tests_ok/autoasciienum_frominc.v
@@ -15,15 +15,15 @@ module sm (/*AUTOARG*/);
    reg [31:0] chip_r__ascii;            // Decode of chip_r
    always @(chip_r) begin
       case ({chip_r})
-        EP_C14ChipNum_RNP:  chip_r__ascii  = "rnp ";
-        EP_C14ChipNum_SPP:  chip_r__ascii  = "spp ";
-        EP_C14ChipNum_SRP:  chip_r__ascii  = "srp ";
-        EP_C14ChipNum_SMM2: chip_r__ascii  = "smm2";
-        EP_C14ChipNum_SMM:  chip_r__ascii  = "smm ";
-        EP_C14ChipNum_TTE:  chip_r__ascii  = "tte ";
-        EP_C14ChipNum_DLE:  chip_r__ascii  = "dle ";
-        EP_C14ChipNum_OASP: chip_r__ascii  = "oasp";
-        default:            chip_r__ascii  = "%Err";
+        EP_C14ChipNum_RNP:  chip_r__ascii = "rnp ";
+        EP_C14ChipNum_SPP:  chip_r__ascii = "spp ";
+        EP_C14ChipNum_SRP:  chip_r__ascii = "srp ";
+        EP_C14ChipNum_SMM2: chip_r__ascii = "smm2";
+        EP_C14ChipNum_SMM:  chip_r__ascii = "smm ";
+        EP_C14ChipNum_TTE:  chip_r__ascii = "tte ";
+        EP_C14ChipNum_DLE:  chip_r__ascii = "dle ";
+        EP_C14ChipNum_OASP: chip_r__ascii = "oasp";
+        default:            chip_r__ascii = "%Err";
       endcase
    end
    // End of automatics

--- a/tests_ok/autoasciienum_onehot.v
+++ b/tests_ok/autoasciienum_onehot.v
@@ -7,24 +7,24 @@ module autoasciienum_onehot (
                              );
    
    localparam // synopsys enum state_info
-     IDLE  = 0,
-     S1    = 1,
-     S2    = 2,
-     S3    = 3,
-     DONE  = 4;
+     IDLE = 0,
+     S1   = 1,
+     S2   = 2,
+     S3   = 3,
+     DONE = 4;
    
    reg [4:0] // synopsys enum state_info
              cur_state, nxt_state;
    
    always @ (*) begin
-      nxt_state  = 5'h0;
+      nxt_state = 5'h0;
       
       case (1'b1)
-        cur_state[IDLE] : nxt_state[S1]    = 1'b1;
-        cur_state[S1]   : nxt_state[S2]    = 1'b1;
-        cur_state[S2]   : nxt_state[S3]    = 1'b1;
-        cur_state[S3]   : nxt_state[DONE]  = 1'b1;
-        cur_state[DONE] : nxt_state[DONE]  = 1'b1;
+        cur_state[IDLE] : nxt_state[S1]   = 1'b1;
+        cur_state[S1]   : nxt_state[S2]   = 1'b1;
+        cur_state[S2]   : nxt_state[S3]   = 1'b1;
+        cur_state[S3]   : nxt_state[DONE] = 1'b1;
+        cur_state[DONE] : nxt_state[DONE] = 1'b1;
       endcase
    end
    
@@ -36,19 +36,19 @@ module autoasciienum_onehot (
         cur_state <= nxt_state;
      end
    
-   assign ack  = cur_state[DONE];
+   assign ack = cur_state[DONE];
    
    /*AUTOASCIIENUM("cur_state", "cur_state_ascii")*/
    // Beginning of automatic ASCII enum decoding
    reg [31:0] cur_state_ascii;  // Decode of cur_state
    always @(cur_state) begin
       case ({cur_state})
-        (5'b1<<IDLE):     cur_state_ascii  = "idle";
-        (5'b1<<S1):       cur_state_ascii  = "s1  ";
-        (5'b1<<S2):       cur_state_ascii  = "s2  ";
-        (5'b1<<S3):       cur_state_ascii  = "s3  ";
-        (5'b1<<DONE):     cur_state_ascii  = "done";
-        default:          cur_state_ascii  = "%Err";
+        (5'b1<<IDLE):     cur_state_ascii = "idle";
+        (5'b1<<S1):       cur_state_ascii = "s1  ";
+        (5'b1<<S2):       cur_state_ascii = "s2  ";
+        (5'b1<<S3):       cur_state_ascii = "s3  ";
+        (5'b1<<DONE):     cur_state_ascii = "done";
+        default:          cur_state_ascii = "%Err";
       endcase
    end
    // End of automatics

--- a/tests_ok/autoasciienum_param.v
+++ b/tests_ok/autoasciienum_param.v
@@ -6,11 +6,11 @@ module just_for_proper_indentation ();
    //Verilint 175 off //WARNING: Unused parameter
    
    parameter // synopsys enum En_C14ChipNum
-     EP_C14ChipNum_OASP  = 4'h0,
-     EP_C14ChipNum_DLE   = 4'h2,
-     EP_C14ChipNum_TTE   = 4'h3,
-     EP_C14ChipNum_SMM   = 4'h4,
-     EP_C14ChipNum_SMM2  = 4'h5,
-     EP_C14ChipNum_SRP   = 4'h6,
-     EP_C14ChipNum_SPP   = 4'h7,
-     EP_C14ChipNum_RNP   = 4'h8;
+     EP_C14ChipNum_OASP = 4'h0,
+     EP_C14ChipNum_DLE  = 4'h2,
+     EP_C14ChipNum_TTE  = 4'h3,
+     EP_C14ChipNum_SMM  = 4'h4,
+     EP_C14ChipNum_SMM2 = 4'h5,
+     EP_C14ChipNum_SRP  = 4'h6,
+     EP_C14ChipNum_SPP  = 4'h7,
+     EP_C14ChipNum_RNP  = 4'h8;

--- a/tests_ok/autoasciienum_reed.v
+++ b/tests_ok/autoasciienum_reed.v
@@ -1,16 +1,16 @@
 
 module sm ();
    
-   localparam STATES  = 7;
+   localparam STATES = 7;
    
    localparam /* synopsys enum states */
-     IDLE         = 0, // '001
-     READ         = 1, // '002
-     THINK        = 2, // '004
-     SEND         = 3, // '008
-     WAIT         = 4, // '040
-     GET_ACK      = 5, // '080
-     WAIT_REGBUS  = 6; // '100
+     IDLE        = 0, // '001
+     READ        = 1, // '002
+     THINK       = 2, // '004
+     SEND        = 3, // '008
+     WAIT        = 4, // '040
+     GET_ACK     = 5, // '080
+     WAIT_REGBUS = 6; // '100
    
    reg [STATES-1:0] /*synopsys enum states*/
                     state_i, state_r; /* synopsys state_vector state_r */
@@ -20,14 +20,14 @@ module sm ();
    reg [87:0]       state_onehot,ascii_r;       // Decode of state_r
    always @(state_r) begin
       case ({state_r})
-        (7'b1<<IDLE):        state_onehot,ascii_r  = "idle       ";
-        (7'b1<<READ):        state_onehot,ascii_r  = "read       ";
-        (7'b1<<THINK):       state_onehot,ascii_r  = "think      ";
-        (7'b1<<SEND):        state_onehot,ascii_r  = "send       ";
-        (7'b1<<WAIT):        state_onehot,ascii_r  = "wait       ";
-        (7'b1<<GET_ACK):     state_onehot,ascii_r  = "get_ack    ";
-        (7'b1<<WAIT_REGBUS): state_onehot,ascii_r  = "wait_regbus";
-        default:             state_onehot,ascii_r  = "%Error     ";
+        (7'b1<<IDLE):        state_onehot,ascii_r = "idle       ";
+        (7'b1<<READ):        state_onehot,ascii_r = "read       ";
+        (7'b1<<THINK):       state_onehot,ascii_r = "think      ";
+        (7'b1<<SEND):        state_onehot,ascii_r = "send       ";
+        (7'b1<<WAIT):        state_onehot,ascii_r = "wait       ";
+        (7'b1<<GET_ACK):     state_onehot,ascii_r = "get_ack    ";
+        (7'b1<<WAIT_REGBUS): state_onehot,ascii_r = "wait_regbus";
+        default:             state_onehot,ascii_r = "%Error     ";
       endcase
    end
    // End of automatics
@@ -37,14 +37,14 @@ module sm ();
    reg [87:0] state_notonehot_ascii_r;// Decode of state_r
    always @(state_r) begin
       case ({state_r})
-        IDLE:        state_notonehot_ascii_r  = "idle       ";
-        READ:        state_notonehot_ascii_r  = "read       ";
-        THINK:       state_notonehot_ascii_r  = "think      ";
-        SEND:        state_notonehot_ascii_r  = "send       ";
-        WAIT:        state_notonehot_ascii_r  = "wait       ";
-        GET_ACK:     state_notonehot_ascii_r  = "get_ack    ";
-        WAIT_REGBUS: state_notonehot_ascii_r  = "wait_regbus";
-        default:     state_notonehot_ascii_r  = "%Error     ";
+        IDLE:        state_notonehot_ascii_r = "idle       ";
+        READ:        state_notonehot_ascii_r = "read       ";
+        THINK:       state_notonehot_ascii_r = "think      ";
+        SEND:        state_notonehot_ascii_r = "send       ";
+        WAIT:        state_notonehot_ascii_r = "wait       ";
+        GET_ACK:     state_notonehot_ascii_r = "get_ack    ";
+        WAIT_REGBUS: state_notonehot_ascii_r = "wait_regbus";
+        default:     state_notonehot_ascii_r = "%Error     ";
       endcase
    end
    // End of automatics

--- a/tests_ok/autoasciienum_sm.v
+++ b/tests_ok/autoasciienum_sm.v
@@ -8,18 +8,18 @@ module sm (/*AUTOARG*/
    //==================== Constant declarations ==============
    
    parameter [2:0]      // synopsys enum state_info
-     IDLE                                                       = 3'b000,
-     SEND                                                       = 3'b001,
-     WAIT1                                                      = 3'b010,
-     UPDATE1                                                    = 3'b011,
-     WAIT2                                                      = 3'b100;
+     IDLE                                                      = 3'b000,
+     SEND                                                      = 3'b001,
+     WAIT1                                                     = 3'b010,
+     UPDATE1                                                   = 3'b011,
+     WAIT2                                                     = 3'b100;
    
-   parameter [2:0]      /* synopsys enum state_info */ UPDATE2  = 3'b101;
+   parameter [2:0]      /* synopsys enum state_info */ UPDATE2 = 3'b101;
    
-   parameter [2:0]      NOT_A_STATE_ELEMENT  = 3'b101;
+   parameter [2:0]      NOT_A_STATE_ELEMENT = 3'b101;
    
    parameter [2:0]      /* synopsys enum other */
-     A_OTHER_STATE_ELEMENT  = 3'b101;
+     A_OTHER_STATE_ELEMENT = 3'b101;
    
    //==================== Input Signals ======================
    
@@ -43,25 +43,25 @@ module sm (/*AUTOARG*/
    always @(/*AUTOSENSE*/state_r) begin
       case(state_r) // synopsys full_case parallel_case
         IDLE: begin
-           state_e1  = SEND;
+           state_e1 = SEND;
         end
         SEND: begin
-           state_e1  = WAIT1;
+           state_e1 = WAIT1;
         end
         WAIT1: begin
-           state_e1  = UPDATE1;
+           state_e1 = UPDATE1;
         end
         UPDATE1: begin
-           state_e1  = UPDATE2;
+           state_e1 = UPDATE2;
         end
         WAIT2: begin
-           state_e1  = UPDATE2;
+           state_e1 = UPDATE2;
         end
         
         UPDATE2: begin
-           state_e1  = IDLE;
+           state_e1 = IDLE;
         end
-        default:        state_e1  = state_r;
+        default:        state_e1 = state_r;
       endcase
    end
    
@@ -81,13 +81,13 @@ module sm (/*AUTOARG*/
    reg [55:0] _stateascii_r;            // Decode of state_r
    always @(state_r) begin
       case ({state_r})
-        IDLE:     _stateascii_r  = "idle   ";
-        SEND:     _stateascii_r  = "send   ";
-        WAIT1:    _stateascii_r  = "wait1  ";
-        UPDATE1:  _stateascii_r  = "update1";
-        WAIT2:    _stateascii_r  = "wait2  ";
-        UPDATE2:  _stateascii_r  = "update2";
-        default:  _stateascii_r  = "%Error ";
+        IDLE:     _stateascii_r = "idle   ";
+        SEND:     _stateascii_r = "send   ";
+        WAIT1:    _stateascii_r = "wait1  ";
+        UPDATE1:  _stateascii_r = "update1";
+        WAIT2:    _stateascii_r = "wait2  ";
+        UPDATE2:  _stateascii_r = "update2";
+        default:  _stateascii_r = "%Error ";
       endcase
    end
    // End of automatics

--- a/tests_ok/autoconst_gesmith.v
+++ b/tests_ok/autoconst_gesmith.v
@@ -5,16 +5,16 @@ module(/*AUTOARG*/)
            /*AUTOSENSE*/b)
     begin
        /*AUTO_CONSTANT(`ot.BOC) */
-       i  = b;
-       c  = `ot.BOC;
-       d  = `ot.BOZ;
+       i = b;
+       c = `ot.BOC;
+       d = `ot.BOZ;
     end
    
    always @(/*AUTOSENSE*/b)
      begin
         /*AUTO_CONSTANT(ot.BOB) */
-        i  = b;
-        c  = ot.BOB;
+        i = b;
+        c = ot.BOB;
      end
    
 endmodule

--- a/tests_ok/autoconstant_gooch.v
+++ b/tests_ok/autoconstant_gooch.v
@@ -22,19 +22,19 @@ module autoconstant_gooch
      begin
         case (in1)
           4'b0001 :     begin
-             out1  = in2;
+             out1 = in2;
           end
           4'b0010 :     begin
-             out1  = in2 + in3;
+             out1 = in2 + in3;
           end
           4'b0100 :     begin
-             out1  = in2 - in3;
+             out1 = in2 - in3;
           end
           4'b1000 :     begin
-             out1  = in2;
+             out1 = in2;
           end
           default       :       begin
-             out1  = {4{1'b0}};
+             out1 = {4{1'b0}};
           end
         endcase
      end
@@ -44,19 +44,19 @@ module autoconstant_gooch
      begin
         case (in1)
           4'b0001 :     begin
-             out2  = in2;
+             out2 = in2;
           end
           4'b0010 :     begin
-             out2  = in2 + in3;
+             out2 = in2 + in3;
           end
           4'b0100 :     begin
-             out2  = in2 - in3;
+             out2 = in2 - in3;
           end
           4'b1000 :     begin
-             out2  = in2;
+             out2 = in2;
           end
           default       :       begin
-             out2  = {4{1'b0}};
+             out2 = {4{1'b0}};
           end
         endcase
      end
@@ -66,8 +66,8 @@ module autoconstant_gooch
      begin
         /* AUTO_CONSTANT( temp )*/
         /* AxxxUTO_CONSTANT temp */
-        out3   = in1 + in2;
-        temp2  = temp;
+        out3  = in1 + in2;
+        temp2 = temp;
         
         // ERROR here - above constant definition is not
         // correct - no braces - and so parser keeps looking
@@ -78,19 +78,19 @@ module autoconstant_gooch
         
         case (in1)
           4'b0001 :     begin
-             out3  = in2;
+             out3 = in2;
           end
           4'b0010 :     begin
-             out3  = in2 + in3;
+             out3 = in2 + in3;
           end
           4'b0100 :     begin
-             out3  = in2 - in3;
+             out3 = in2 - in3;
           end
           4'b1000 :     begin
-             out3  = in2;
+             out3 = in2;
           end
           default       :       begin
-             out3  = {4{1'b0}};
+             out3 = {4{1'b0}};
           end
         endcase
      end

--- a/tests_ok/autoinoutmodport_bourduas_type.v
+++ b/tests_ok/autoinoutmodport_bourduas_type.v
@@ -11,9 +11,9 @@ module apl2c_connect(autoinoutmodport_type_intf ctl_i,
    
    /*AUTOASSIGNMODPORT("autoinoutmodport_type_intf", "ctl_cb", "ctl_i")*/
    // Beginning of automatic assignments from modport
-   assign ctl_i.inst  = inst;
-   assign ctl_i.isel  = isel;
-   assign ctl_i.replay  = replay;
+   assign ctl_i.inst = inst;
+   assign ctl_i.isel = isel;
+   assign ctl_i.replay = replay;
    // End of automatics
    
 endmodule

--- a/tests_ok/autoinst_clog2_bug522.v
+++ b/tests_ok/autoinst_clog2_bug522.v
@@ -19,8 +19,8 @@ module submod (/*AUTOARG*/
                // Inputs
                vec
                );
-   parameter VEC_W  = 32;
-   parameter IDX_W  = $clog2(VEC_W);
+   parameter VEC_W = 32;
+   parameter IDX_W = $clog2(VEC_W);
    input [VEC_W-1:0]  vec;
    output [IDX_W-1:0] idx;
 endmodule

--- a/tests_ok/autoinst_ifdef_fredrickson_200503_sub.v
+++ b/tests_ok/autoinst_ifdef_fredrickson_200503_sub.v
@@ -7,9 +7,9 @@ module autoinst_ifdef_fredrickson_200503_sub
    output wire b
    );
    
-   assign b  = a;
+   assign b = a;
 `ifdef TEST
-   assign d  = c;
+   assign d = c;
 `endif
    
 endmodule // define_sub

--- a/tests_ok/autoinst_import2012.v
+++ b/tests_ok/autoinst_import2012.v
@@ -15,7 +15,7 @@ interface bus (input clk, rst_n);
 endinterface
 
 package common_pkg;
-   parameter NUM_SLAVES  = 2;
+   parameter NUM_SLAVES = 2;
    // typedefs ...
 endpackage
    

--- a/tests_ok/autoinst_lopaz.v
+++ b/tests_ok/autoinst_lopaz.v
@@ -2,9 +2,9 @@ module io1_sub(
                /*AUTOARG*/);
    
    wire [42:0] bscan_data;         // boundary scan stitch
-   parameter    bscan_count  = 0;
+   parameter    bscan_count = 0;
    
-   assign       bscan_data[0]  = bscan_in;
+   assign       bscan_data[0] = bscan_in;
    
    /*
     * Emacs template to auto instaniate MD[31:0] pads

--- a/tests_ok/autoinst_lopaz_srpad.v
+++ b/tests_ok/autoinst_lopaz_srpad.v
@@ -6,7 +6,7 @@ module autoinst_lopaz_srpad (/*AUTOARG*/
                              // Inputs
                              clk, pin_out, pin_outen
                              );
-   parameter w  = 1;
+   parameter w = 1;
    input            clk;
    
    inout [w-1:0]    pin;

--- a/tests_ok/autoinst_overflow_bug250.v
+++ b/tests_ok/autoinst_overflow_bug250.v
@@ -425,5 +425,5 @@ module TEST_TOP (
 endmodule
 
 module TEST (/*AUTOARG*/);
-   parameter NO  = 6456;
+   parameter NO = 6456;
 endmodule

--- a/tests_ok/autoinst_param_type.v
+++ b/tests_ok/autoinst_param_type.v
@@ -45,7 +45,7 @@ module ptype_buf
     parameter type TYPE_T = logic [WIDTH-1:0])
    (output TYPE_T y,
     input TYPE_T a);
-   assign y  = a;
+   assign y = a;
 endmodule
 
 ///--------------

--- a/tests_ok/autoinst_paramover.v
+++ b/tests_ok/autoinst_paramover.v
@@ -7,8 +7,8 @@ module autoinst_paramover (/*AUTOARG*/
    // Inputs/Outputs
    //======================================================================
    
-   parameter bitsa  = 20;
-   parameter bitsb  = 20;
+   parameter bitsa = 20;
+   parameter bitsb = 20;
    
    inout [20:0] a; // SDRAM Channel 0 Row Address Strobe
    inout [20:0] b;         // SDRAM Channel 0 Row Address Strobe

--- a/tests_ok/autoinst_sv_kulkarni.v
+++ b/tests_ok/autoinst_sv_kulkarni.v
@@ -58,17 +58,17 @@ module top;
    
    // Stimulus
    initial begin
-      a_i1  = { 4'h0, 4'h2 };
+      a_i1 = { 4'h0, 4'h2 };
       #5;
       $display("Loop Init: a_i1 = { %h, %h }   a_o1 = %h\n",
                a_i1[1], a_i1[0], a_o1);
       #5;
       for (int i=0; i<1; i++) begin
          for (int j=0; j<N; j++) begin
-            temp  = 1'b0;
+            temp = 1'b0;
             for (int k=0; k<M; k++) begin
-               a_i1[j][k]  = temp;
-               temp        = ~temp;
+               a_i1[j][k] = temp;
+               temp       = ~temp;
             end
          end
          #5;

--- a/tests_ok/autoinst_sv_kulkarni_base.v
+++ b/tests_ok/autoinst_sv_kulkarni_base.v
@@ -15,7 +15,7 @@ module autoinst_sv_kulkarni_base
    // Main Code
    always_comb begin
       for (int i=0; i<N; i++)
-        a_o1[i]  = ^(a_i1[i]);
+        a_o1[i] = ^(a_i1[i]);
    end
    
 endmodule

--- a/tests_ok/autoinstparam_belkind.v
+++ b/tests_ok/autoinstparam_belkind.v
@@ -1,6 +1,6 @@
 module autoinstparam_belkind (/*AUTOARG*/) ;
    
-   parameter X  = 8;
+   parameter X = 8;
    /*
     autoinstparam_belkind_leaf AUTO_TEMPLATE (
     .P (X),

--- a/tests_ok/autoinstparam_first_sub.v
+++ b/tests_ok/autoinstparam_first_sub.v
@@ -9,7 +9,7 @@ module autoinstparam_first_sub (/*AUTOARG*/
    
    localparam IGNORED;
    parameter BITSA;
-   parameter type BITSB_t  = bit;   // See bug340
+   parameter type BITSB_t = bit;   // See bug340
    
    inout [BITSA:0] a;
    inout           BITSB_t b;

--- a/tests_ok/autolisp_include.v
+++ b/tests_ok/autolisp_include.v
@@ -13,7 +13,7 @@ module autolisp_include (/*AUTOARG*/
    output foo;
    // End of automatics
    
-   assign foo  = bar;
+   assign foo = bar;
    
    // This doesn't need commentary
    /*AUTOINSERTLISP(when nil)*/

--- a/tests_ok/automodport_ex.v
+++ b/tests_ok/automodport_ex.v
@@ -20,8 +20,8 @@ module ExampMain
    
    /*AUTOASSIGNMODPORT("ExampIf" "mp" "inst")*/
    // Beginning of automatic assignments from modport
-   assign inst.req_dat  = req_dat;
-   assign inst.req_val  = req_val;
+   assign inst.req_dat = req_dat;
+   assign inst.req_val = req_val;
    // End of automatics
    
 endmodule

--- a/tests_ok/automodport_full.v
+++ b/tests_ok/automodport_full.v
@@ -42,10 +42,10 @@ module auto_module
    
    /*AUTOASSIGNMODPORT("automodport_if" "req_mon_mp" "auto_i" )*/
    // Beginning of automatic assignments from modport
-   assign auto_i.manually_listed  = manually_listed;
-   assign auto_i.req_credit  = req_credit;
-   assign auto_i.req_dat  = req_dat;
-   assign auto_i.req_val  = req_val;
+   assign auto_i.manually_listed = manually_listed;
+   assign auto_i.req_credit = req_credit;
+   assign auto_i.req_dat = req_dat;
+   assign auto_i.req_val = req_val;
    // End of automatics
    //ex: assign auto_i.req_credit         = req_credit;
    //ex: assign auto_i.req_data           = req_data;
@@ -53,9 +53,9 @@ module auto_module
    
    /*AUTOASSIGNMODPORT("automodport_if" "rsp_drv_mp" "auto_i" )*/
    // Beginning of automatic assignments from modport
-   assign rsp_cmd  = auto_i.rsp_cmd;
-   assign rsp_data  = auto_i.rsp_data;
-   assign auto_i.rsp_credit  = rsp_credit;
+   assign rsp_cmd = auto_i.rsp_cmd;
+   assign rsp_data = auto_i.rsp_data;
+   assign auto_i.rsp_credit = rsp_credit;
    // End of automatics
    //ex: assign rsp_cmd                   = auto_i.rsp_cmd;
    //ex: assign rsp_data                  = auto_i.rsp_data;
@@ -63,13 +63,13 @@ module auto_module
    
    /*AUTOASSIGNMODPORT("automodport_if" "r.*" "auto_i" )*/
    // Beginning of automatic assignments from modport
-   assign rsp_cmd  = auto_i.rsp_cmd;
-   assign rsp_data  = auto_i.rsp_data;
-   assign auto_i.manually_listed  = manually_listed;
-   assign auto_i.req_credit  = req_credit;
-   assign auto_i.req_dat  = req_dat;
-   assign auto_i.req_val  = req_val;
-   assign auto_i.rsp_credit  = rsp_credit;
+   assign rsp_cmd = auto_i.rsp_cmd;
+   assign rsp_data = auto_i.rsp_data;
+   assign auto_i.manually_listed = manually_listed;
+   assign auto_i.req_credit = req_credit;
+   assign auto_i.req_dat = req_dat;
+   assign auto_i.req_val = req_val;
+   assign auto_i.rsp_credit = rsp_credit;
    // End of automatics
    
    

--- a/tests_ok/automodport_if.v
+++ b/tests_ok/automodport_if.v
@@ -43,8 +43,8 @@ interface automodport_if
    //----------------------------------------------------------------------------------------
    // Group: Methods
    function void rsp_reset();
-      rsp_cmd   = 2'b0;
-      rsp_data  = 64'b0;
+      rsp_cmd  = 2'b0;
+      rsp_data = 64'b0;
    endfunction : rsp_reset
    
    //----------------------------------------------------------------------------------------

--- a/tests_ok/autooutputevery_assign.v
+++ b/tests_ok/autooutputevery_assign.v
@@ -12,7 +12,7 @@ module ex_output_every (o,i,tempa,tempb)
    wire   tempb;
    wire   o;
    
-   assign tempa  = i;
-   assign tempb  = tempa;
-   assign o  = tempb;
+   assign tempa = i;
+   assign tempb = tempa;
+   assign o = tempb;
 endmodule

--- a/tests_ok/autooutputevery_wire.v
+++ b/tests_ok/autooutputevery_wire.v
@@ -60,6 +60,6 @@ module sub_module (/*AUTOARG*/
    input logic [7:0]  i_bus ;
    output logic [7:0] o_bus ;
    
-   assign o_bus  = i_bus;
+   assign o_bus = i_bus;
    
 endmodule // sub_module

--- a/tests_ok/autoreg_smith_multiassign.v
+++ b/tests_ok/autoreg_smith_multiassign.v
@@ -11,9 +11,9 @@ module test(/*AUTOARG*/
    
    //wire [5:0]   a2,b2,c2;
    
-   assign {a1,b1,c1}  = {a2,b2,c2};
+   assign {a1,b1,c1} = {a2,b2,c2};
    
    output [1:0] one;
-   assign one  = a2[0];
+   assign one = a2[0];
    
 endmodule

--- a/tests_ok/autoreset_dever.v
+++ b/tests_ok/autoreset_dever.v
@@ -12,7 +12,7 @@ module x;
    end
    
    // 2010-04-08
-   localparam MPND  = 5;
+   localparam MPND = 5;
    always @(posedge usclk)
      if (~sso_srst_n) begin
         /*AUTORESET*/

--- a/tests_ok/autoreset_eq_bug381.v
+++ b/tests_ok/autoreset_eq_bug381.v
@@ -14,7 +14,7 @@ module t();
       end
       else begin
          //reg [32:0] tmp;
-         tmp  = a + b;
+         tmp = a + b;
          if (tmp[32])
            sum <= 32'hffffffff;
          else

--- a/tests_ok/autoreset_eq_bug381_non.v
+++ b/tests_ok/autoreset_eq_bug381_non.v
@@ -15,7 +15,7 @@ module t();
       end
       else begin
          //reg [32:0] tmp;
-         tmp  = a + b;
+         tmp = a + b;
          if (tmp[32])
            sum <= 32'hffffffff;
          else

--- a/tests_ok/autoreset_if.v
+++ b/tests_ok/autoreset_if.v
@@ -52,15 +52,15 @@ module x (/*AUTOARG*/
    always @(/*AS*/in_a or in_b or reset_l) begin
       casex ({reset_l,in_a})
         2'b1_x: begin
-           a  = in_a;
-           b  = in_b;
+           a = in_a;
+           b = in_b;
         end
         2'b0_x: begin
-           c  = 1;
+           c = 1;
            /*AUTORESET*/
            // Beginning of autoreset for uninitialized flops
-           a  = 0;
-           b  = 0;
+           a = 0;
+           b = 0;
            // End of automatics
         end
       endcase

--- a/tests_ok/autoreset_latch.v
+++ b/tests_ok/autoreset_latch.v
@@ -30,21 +30,21 @@ module device(
       if (!ready) begin
          /*AUTORESET*/
          // Beginning of autoreset for uninitialized flops
-         out0  = 8'h0;
+         out0 = 8'h0;
          // End of automatics
       end
       else begin
-         out0  = sel ? in1 : in0;
+         out0 = sel ? in1 : in0;
       end
    end
    
    always_comb begin
-      next_state  = state;
+      next_state = state;
       /*AUTORESET*/
       // Beginning of autoreset for uninitialized flops
-      next_fail   = 1'h0;
-      next_pass   = 1'h0;
-      next_ready  = 1'h0;
+      next_fail  = 1'h0;
+      next_pass  = 1'h0;
+      next_ready = 1'h0;
       // End of automatics
       case (state)
         IDLE :  begin
@@ -52,15 +52,15 @@ module device(
         end
         /* Other states */
         PASS:   begin
-           next_state  = IDLE;
+           next_state = IDLE;
            // stuff ...
-           next_pass   = 1'b1;
-           next_ready  = 1'b1;
+           next_pass  = 1'b1;
+           next_ready = 1'b1;
         end
         FAIL:   begin
-           next_state  = IDLE;
+           next_state = IDLE;
            // stuff ...
-           next_fail   = 1'b1;
+           next_fail  = 1'b1;
         end
       endcase
    end

--- a/tests_ok/autoreset_reed.v
+++ b/tests_ok/autoreset_reed.v
@@ -6,15 +6,15 @@ module x;
       if ( rst ) begin
          /*AUTORESET*/
          // Beginning of autoreset for uninitialized flops
-         c  = 1'h0;
+         c = 1'h0;
          // End of automatics
       end
       else begin
          if ( a <= b ) begin
-            c  = a;
+            c = a;
          end
          else begin
-            c  = b;
+            c = b;
          end
       end
    end

--- a/tests_ok/autoreset_struct.v
+++ b/tests_ok/autoreset_struct.v
@@ -10,55 +10,55 @@ module gminstdecode
    always_comb begin
       /*AUTORESET*/
       // Beginning of autoreset for uninitialized flops
-      instClass.iFunc           = '0;
-      instClass.isBool          = '0;
-      instClass.sub.bool        = '0;
-      instClass.sub2.sub3.bool  = '0;
+      instClass.iFunc          = '0;
+      instClass.isBool         = '0;
+      instClass.sub.bool       = '0;
+      instClass.sub2.sub3.bool = '0;
       // End of automatics
       
       if (ldBitFromIo | stBitToIo) begin
-         instClass.isBool          = 1'b1;
-         instClass.iFunc           = IFUNC_BOOL;
-         instClass.sub.bool        = 1'b1;
-         instClass.sub2.sub3.bool  = 1'b1;
+         instClass.isBool         = 1'b1;
+         instClass.iFunc          = IFUNC_BOOL;
+         instClass.sub.bool       = 1'b1;
+         instClass.sub2.sub3.bool = 1'b1;
       end
    end
    
    always_comb begin
-      instClass  = '{default:0};     // #1 (see below)
+      instClass = '{default:0};     // #1 (see below)
       /*AUTORESET*/
       
       if (ldBitFromIo | stBitToIo) begin
-         instClass.isBool  = 1'b1;
-         instClass.iFunc   = IFUNC_BOOL;
+         instClass.isBool = 1'b1;
+         instClass.iFunc  = IFUNC_BOOL;
       end
    end
    
    always_comb begin
-      instClass.iFunc   = IFUNC_ADD;  // #2
-      /*AUTORESET*/
-      // Beginning of autoreset for uninitialized flops
-      instClass.isBool  = '0;
-      // End of automatics
-      
-      if (ldBitFromIo | stBitToIo) begin
-         instClass.isBool  = 1'b1;
-         instClass.iFunc   = IFUNC_BOOL;
-      end
-   end
-   
-   always_comb begin
-      instClass.sub             = '0;
-      instClass.sub2            = '0;
+      instClass.iFunc  = IFUNC_ADD;  // #2
       /*AUTORESET*/
       // Beginning of autoreset for uninitialized flops
-      instClass.sub3.sub4.bool  = '0;
+      instClass.isBool = '0;
       // End of automatics
       
       if (ldBitFromIo | stBitToIo) begin
-         instClass.sub.bool        = 1'b1;
-         instClass.sub2.sub3.bool  = 1'b1;
-         instClass.sub3.sub4.bool  = 1'b1;
+         instClass.isBool = 1'b1;
+         instClass.iFunc  = IFUNC_BOOL;
+      end
+   end
+   
+   always_comb begin
+      instClass.sub            = '0;
+      instClass.sub2           = '0;
+      /*AUTORESET*/
+      // Beginning of autoreset for uninitialized flops
+      instClass.sub3.sub4.bool = '0;
+      // End of automatics
+      
+      if (ldBitFromIo | stBitToIo) begin
+         instClass.sub.bool       = 1'b1;
+         instClass.sub2.sub3.bool = 1'b1;
+         instClass.sub3.sub4.bool = 1'b1;
       end
    end
 endmodule

--- a/tests_ok/autoreset_widths.v
+++ b/tests_ok/autoreset_widths.v
@@ -30,8 +30,8 @@ module CmpEng (/*AUTOARG*/
    
 `define M 2
 `define L 1
-   parameter MS  = 2;
-   parameter LS  = 1;
+   parameter MS = 2;
+   parameter LS = 1;
    
    reg [MS:LS] m_param_r;
    reg [`M:`L] m_def2_r;

--- a/tests_ok/autoreset_widths_unbased.v
+++ b/tests_ok/autoreset_widths_unbased.v
@@ -30,8 +30,8 @@ module CmpEng (/*AUTOARG*/
    
 `define M 2
 `define L 1
-   parameter MS  = 2;
-   parameter LS  = 1;
+   parameter MS = 2;
+   parameter LS = 1;
    
    reg [MS:LS] m_param_r;
    reg [`M:`L] m_def2_r;

--- a/tests_ok/autosense.v
+++ b/tests_ok/autosense.v
@@ -23,23 +23,23 @@ module autosense (/*AUTOARG*/
    
    always @(/*AUTOSENSE*/ina or inb or inc) begin
       case (inc)
-        1'b1: out     = {`Input ? `one : 1'b0, `Input};
-        default: out  = {2{inb}};
+        1'b1: out    = {`Input ? `one : 1'b0, `Input};
+        default: out = {2{inb}};
       endcase
    end
    
    
    always @(/*AUTOSENSE*/ina) begin
-      out2  = `Input | PARAM_TWO | PARAM_THREE | PARAM_FOUR;
+      out2 = `Input | PARAM_TWO | PARAM_THREE | PARAM_FOUR;
    end
    
    always @(*) begin
       // @ (/*AS*/)
-      out3  = ina;
+      out3 = ina;
    end
    
    always @* begin
-      out3  = ina;
+      out3 = ina;
    end
    
 endmodule

--- a/tests_ok/autosense_aas_ifdef.v
+++ b/tests_ok/autosense_aas_ifdef.v
@@ -1,48 +1,48 @@
 module dummy;
    
    parameter [TSTBITS-1:0] // synopsys enum tstate_info
-     TIDLE  = 3'b000,
-     TCN1   = 3'b001,
-     TCN2   = TCN1+1, // must be numbered consecutively
-     TCN3   = TCN2+1,
-     TCN4   = TCN3+1,
-     TCN5   = TCN4+1,
-     IOCLR  = TCN5+1,
-     TUNU1  = 3'b111;
+     TIDLE = 3'b000,
+     TCN1  = 3'b001,
+     TCN2  = TCN1+1, // must be numbered consecutively
+     TCN3  = TCN2+1,
+     TCN4  = TCN3+1,
+     TCN5  = TCN4+1,
+     IOCLR = TCN5+1,
+     TUNU1 = 3'b111;
    
    // state and output logic
    always @ (`ifdef SIMFSM
              ireset or
 `endif
              /*AUTOSENSE*/fooc2_qual or foocr_we or ioclrinst or tstate) begin
-      ioclrtmout  = 1'b0;
+      ioclrtmout = 1'b0;
       case (tstate)
         TIDLE: begin
            if (foocr_we)
-             ntstate  = TCN1;
+             ntstate = TCN1;
            else
-             ntstate  = TIDLE;
+             ntstate = TIDLE;
         end
         TCN1,TCN2,TCN3,TCN4,TCN5: begin
            if (ioclrinst | fooc2_qual)
-             ntstate  = TIDLE;
+             ntstate = TIDLE;
            else
-             ntstate  = tstate + 1;
+             ntstate = tstate + 1;
         end
         IOCLR: begin
-           ntstate     = TIDLE;
-           ioclrtmout  = 1'b1;
+           ntstate    = TIDLE;
+           ioclrtmout = 1'b1;
         end
         TUNU1: begin
-           ntstate  = TIDLE;
+           ntstate = TIDLE;
 `ifdef SIMFSM
            if (~ireset)
              $display("ERROR: entered unused state at %t",$time);
 `endif
         end
         default: begin
-           ntstate     = 'bx;
-           ioclrtmout  = 1'bx;
+           ntstate    = 'bx;
+           ioclrtmout = 1'bx;
 `ifdef SIMFSM
            if (~ireset)
              $display("ERROR: entered unknown state at %t",$time);

--- a/tests_ok/autosense_add_or.v
+++ b/tests_ok/autosense_add_or.v
@@ -11,10 +11,10 @@ module autosense_or(/*AUTOARG*/
    output y;
    
    always @(a/*AUTOSENSE*/) begin
-      x  = a;
+      x = a;
    end
    always @(a/*AUTOSENSE*/ or c) begin
-      x  = a | c;
+      x = a | c;
    end
    //   always @(a or/*AUTOSENSE*/c) begin
    //      x = a | c;

--- a/tests_ok/autosense_chadha.v
+++ b/tests_ok/autosense_chadha.v
@@ -18,20 +18,20 @@ module test (/*AUTOARG*/
    always @ (/*AS*/in0 or in1 or in2 or sel)
      if (sel == 2'b00)
        begin
-          out1  = in1;
-          out2  = in0;
+          out1 = in1;
+          out2 = in0;
        end
      else
        begin
-          out1  = in2;
-          out2  = in1;
+          out1 = in2;
+          out2 = in1;
        end
    
    // OK
    always @ (/*AS*/in1 or in2 or sel)
      if (sel == 2'b00)
-       out1  = in1;
+       out1 = in1;
      else
-       out1  = in2;
+       out1 = in2;
    
 endmodule // test

--- a/tests_ok/autosense_dittrich.v
+++ b/tests_ok/autosense_dittrich.v
@@ -14,11 +14,11 @@ module testcase
    
    always @(/*AS*/A or B or C or D or SEL) begin
       case (SEL)
-        sel_a: Z    = A;
-        sel_b: Z    = B;
-        sel_c: Z    = C;
-        sel_d: Z    = D;
-        default: Z  = D;
+        sel_a: Z   = A;
+        sel_b: Z   = B;
+        sel_c: Z   = C;
+        sel_d: Z   = D;
+        default: Z = D;
       endcase // case(SEL)
    end // always @ (...
    

--- a/tests_ok/autosense_dittrich_inc.v
+++ b/tests_ok/autosense_dittrich_inc.v
@@ -1,7 +1,7 @@
 parameter sel_a = {1'b 0, 1'b 0}; // 2'd 0 works fine
 parameter sel_b = {1'b 0, 1'b 1}; // 2'd 1 works fine
 parameter sel_c = 2'd 2,
-  sel_d  = 2'd 3;
+  sel_d = 2'd 3;
 
 //parameter sel_a = {1'b 0, 1'b 0}, // 2'd 0 works fine
 //        sel_b = {1'b 0, 1'b 1}, // 2'd 1 works fine

--- a/tests_ok/autosense_gifford.v
+++ b/tests_ok/autosense_gifford.v
@@ -12,15 +12,15 @@ module x (/*AUTOARG*/);
           case ({lio_buscfg_brstlen4_sr,lio_buscfg_brstlen2_sr})
             2'b01: // 2-burst
               begin
-                 ibnk_sel_s  = m_cdq_haddr_sr[`DMC_AG_HADDR_BADDR_BST2_RNG];
+                 ibnk_sel_s = m_cdq_haddr_sr[`DMC_AG_HADDR_BADDR_BST2_RNG];
               end
             2'b10: // 4-burst
               begin
-                 ibnk_sel_s  = m_cdq_haddr_sr[`DMC_AG_HADDR_BADDR_BST4_RNG];
+                 ibnk_sel_s = m_cdq_haddr_sr[`DMC_AG_HADDR_BADDR_BST4_RNG];
               end
             default: // 8-burst
               begin
-                 ibnk_sel_s  = m_cdq_haddr_sr[`DMC_AG_HADDR_BADDR_BST8_RNG];
+                 ibnk_sel_s = m_cdq_haddr_sr[`DMC_AG_HADDR_BADDR_BST8_RNG];
               end
           endcase
        end

--- a/tests_ok/autosense_if_else.v
+++ b/tests_ok/autosense_if_else.v
@@ -1,13 +1,13 @@
 module x;
    
    always @ (/*AS*/a or b or c)
-     if (a) q  = b;
-   else r  = c;
+     if (a) q = b;
+   else r = c;
    
    always @ (/*AS*/a or b or c or d or e)
-     if (a) q  = b;
-   else if (c) r  = d;
+     if (a) q = b;
+   else if (c) r = d;
    /* skip comments as usual */
-   else r  = e;
+   else r = e;
    
 endmodule

--- a/tests_ok/autosense_inc_param.v
+++ b/tests_ok/autosense_inc_param.v
@@ -1,6 +1,6 @@
 
 parameter [2:0] PARAM_TWO = 2,
-  PARAM_THREE  = 3;
+  PARAM_THREE = 3;
 parameter PARAM_FOUR = 4;
 
 

--- a/tests_ok/autosense_lavinge.v
+++ b/tests_ok/autosense_lavinge.v
@@ -10,6 +10,6 @@ module test
    always @(/*AUTOSENSE*/b or d)
      begin
         c=0;
-        if (d) c  = b;
+        if (d) c = b;
      end
 endmodule

--- a/tests_ok/autosense_mcardle_onehot.v
+++ b/tests_ok/autosense_mcardle_onehot.v
@@ -3,25 +3,25 @@ module x;
    input [5:0]  state;
    output [5:0] next;
    
-   parameter    CYCLEA  = 1;
-   parameter    CYCLEC  = 2;
-   parameter    MSTRA  = 3;
-   parameter    MSTRB  = 4;
-   parameter    MSTRC  = 5;
+   parameter    CYCLEA = 1;
+   parameter    CYCLEC = 2;
+   parameter    MSTRA = 3;
+   parameter    MSTRB = 4;
+   parameter    MSTRC = 5;
    
    // make sure 'state' is listed
    always @ (/*AUTOSENSE*/done or nREQA or nREQB or nREQC or state) begin
-      next  = 6'b0;
+      next = 6'b0;
       case (1'b1)
         state[CYCLEC] : begin
-           if (!nREQA && done)                         next[MSTRA]  = 1'b1;
-           else if (!nREQB && nREQA && done)next[MSTRB]  = 1'b1;
-           else if (!nREQC && nREQA && nREQB && done) next[MSTRC]  = 1'b1;
-           else next[CYCLEC]  = 1'b1;
+           if (!nREQA && done)                         next[MSTRA] = 1'b1;
+           else if (!nREQB && nREQA && done)next[MSTRB] = 1'b1;
+           else if (!nREQC && nREQA && nREQB && done) next[MSTRC] = 1'b1;
+           else next[CYCLEC] = 1'b1;
         end
         state[MSTRA] : begin
-           if (!nREQB || !nREQC) next[CYCLEA]  = 1'b1;
-           else                           next[MSTRA]  = 1'b1;
+           if (!nREQB || !nREQC) next[CYCLEA] = 1'b1;
+           else                           next[MSTRA] = 1'b1;
         end
       endcase
    end

--- a/tests_ok/autosense_metzger_space.v
+++ b/tests_ok/autosense_metzger_space.v
@@ -14,8 +14,8 @@ module x (/*AUTOARG*/
    output rmsk1;
    output rmsk2;
    
-   always @ (/*AS*/endbyte0 or strtbyte0) rmsk0  = maskcalc(strtbyte0,endbyte0);
-   always @ (/*AS*/endbyte1 or strtbyte1) rmsk1  = maskcalc(strtbyte1,endbyte1);
-   always @ (/*AS*/endbyte2 or strtbyte2) rmsk2  = maskcalc(strtbyte2,endbyte2);
+   always @ (/*AS*/endbyte0 or strtbyte0) rmsk0 = maskcalc(strtbyte0,endbyte0);
+   always @ (/*AS*/endbyte1 or strtbyte1) rmsk1 = maskcalc(strtbyte1,endbyte1);
+   always @ (/*AS*/endbyte2 or strtbyte2) rmsk2 = maskcalc(strtbyte2,endbyte2);
    
 endmodule

--- a/tests_ok/autosense_peers_func.v
+++ b/tests_ok/autosense_peers_func.v
@@ -1,18 +1,18 @@
 module x;
    
    always @(/*AUTOSENSE*/arb_select_f or octet_idx) begin
-      octet_flag[0]    = |arb_select_f[ 7: 0];
-      octet_flag[1]    = |arb_select_f[15: 8];
-      octet_flag[2]    = |arb_select_f[23:16];
-      octet_flag[3]    = |arb_select_f[31:24];
-      octet_flag[4]    = |arb_select_f[39:32];
-      octet_flag[5]    = |arb_select_f[47:40];
-      octet_flag[6]    = |arb_select_f[55:48];
-      octet_flag[7]    = |arb_select_f[63:56];
+      octet_flag[0]   = |arb_select_f[ 7: 0];
+      octet_flag[1]   = |arb_select_f[15: 8];
+      octet_flag[2]   = |arb_select_f[23:16];
+      octet_flag[3]   = |arb_select_f[31:24];
+      octet_flag[4]   = |arb_select_f[39:32];
+      octet_flag[5]   = |arb_select_f[47:40];
+      octet_flag[6]   = |arb_select_f[55:48];
+      octet_flag[7]   = |arb_select_f[63:56];
       
-      octet_available  = |octet_flag;
+      octet_available = |octet_flag;
       
-      shifted8_64      = barrel_shifter(octet_flag, octet_idx[5:3]);
+      shifted8_64     = barrel_shifter(octet_flag, octet_idx[5:3]);
    end // always @ (arb_select_f)
    
 endmodule
@@ -24,14 +24,14 @@ function [7:0] barrel_shifter;
    
    begin
       case (shift_amt) //synopsys parallel_case full_case
-        3'b0: barrel_shifter  = source;
-        3'b1: barrel_shifter  = {source[0], source[7:1]};
-        3'b2: barrel_shifter  = {source[1:0], source[7:2]};
-        3'b3: barrel_shifter  = {source[2:0], source[7:3]};
-        3'b4: barrel_shifter  = {source[3:0], source[7:4]};
-        3'b5: barrel_shifter  = {source[4:0], source[7:5]};
-        3'b6: barrel_shifter  = {source[5:0], source[7:6]};
-        3'b7: barrel_shifter  = {source[6:0], source[7]};
+        3'b0: barrel_shifter = source;
+        3'b1: barrel_shifter = {source[0], source[7:1]};
+        3'b2: barrel_shifter = {source[1:0], source[7:2]};
+        3'b3: barrel_shifter = {source[2:0], source[7:3]};
+        3'b4: barrel_shifter = {source[3:0], source[7:4]};
+        3'b5: barrel_shifter = {source[4:0], source[7:5]};
+        3'b6: barrel_shifter = {source[5:0], source[7:6]};
+        3'b7: barrel_shifter = {source[6:0], source[7]};
       endcase // case(shift_amt)
    end
    

--- a/tests_ok/autosense_smith.v
+++ b/tests_ok/autosense_smith.v
@@ -4,27 +4,27 @@ module x;
    
    // 16 registers max, register 15 is always the version number, so 15 are useable
    // NOTE: number_interface_regs must be the maximum (or 16 in this case) to get the version register
-   parameter               NUMBER_INTERFACE_REGS  = 16;
-   parameter               MB_REG_START  = 3; // start at 4th register location 'h0010
-   parameter               CMD_REG_0_ADDR  = MB_REG_START;
-   parameter               CMD_REG_1_ADDR  = MB_REG_START+1;
-   parameter               CMD_REG_2_ADDR  = MB_REG_START+2;
-   parameter               CMD_REG_3_ADDR  = MB_REG_START+3;
-   parameter               CMD_REG_4_ADDR  = MB_REG_START+4;
-   parameter               CMD_REG_5_ADDR  = MB_REG_START+5;
-   parameter               CMD_REG_6_ADDR  = MB_REG_START+6;
-   parameter               CMD_REG_7_ADDR  = MB_REG_START+7;
-   parameter               CMD_REG_8_ADDR  = MB_REG_START+8;
-   parameter               CMD_REG_9_ADDR  = MB_REG_START+9;
-   parameter               CMD_REG_10_ADDR  = MB_REG_START+10;
+   parameter               NUMBER_INTERFACE_REGS = 16;
+   parameter               MB_REG_START = 3; // start at 4th register location 'h0010
+   parameter               CMD_REG_0_ADDR = MB_REG_START;
+   parameter               CMD_REG_1_ADDR = MB_REG_START+1;
+   parameter               CMD_REG_2_ADDR = MB_REG_START+2;
+   parameter               CMD_REG_3_ADDR = MB_REG_START+3;
+   parameter               CMD_REG_4_ADDR = MB_REG_START+4;
+   parameter               CMD_REG_5_ADDR = MB_REG_START+5;
+   parameter               CMD_REG_6_ADDR = MB_REG_START+6;
+   parameter               CMD_REG_7_ADDR = MB_REG_START+7;
+   parameter               CMD_REG_8_ADDR = MB_REG_START+8;
+   parameter               CMD_REG_9_ADDR = MB_REG_START+9;
+   parameter               CMD_REG_10_ADDR = MB_REG_START+10;
    // mode regs
-   parameter               MODE_REG_0_ADDR  = CMD_REG_8_ADDR;
+   parameter               MODE_REG_0_ADDR = CMD_REG_8_ADDR;
    
    // Absolute register 14 is Error counter
-   parameter               CMD_REG_14_ADDR  = 14;
-   parameter               CRC_ERROR_REG_ADDR  = CMD_REG_14_ADDR;
+   parameter               CMD_REG_14_ADDR = 14;
+   parameter               CRC_ERROR_REG_ADDR = CMD_REG_14_ADDR;
    // ------------ VERSION register is 15
-   parameter               VERSION_REG_ADDR  = 15;
+   parameter               VERSION_REG_ADDR = 15;
    
    reg [NUMBER_INTERFACE_REGS-1:MB_REG_START] mb_reg_wr;
    reg [NUMBER_INTERFACE_REGS-1:MB_REG_START] mb_reg_rd;
@@ -32,24 +32,24 @@ module x;
    wire [31:0]                                interface_from_core_fp;
    
    assign
-     mb_reg_out_w[VERSION_REG_ADDR]  = BUILD_VERSION;
+     mb_reg_out_w[VERSION_REG_ADDR] = BUILD_VERSION;
    
    integer mb_loop;
    always @(/*AUTOSENSE*/ /*memory or*/ interface_from_core_fp or mb_reg_rwn or mb_reg_select)
      
      begin: MB_READ_WRITE_SEL_P
         
-        mb_reg_wr      = 'h0;
-        mb_reg_rd      = 'h0;
-        mb_reg_output  = interface_from_core_fp;
+        mb_reg_wr     = 'h0;
+        mb_reg_rd     = 'h0;
+        mb_reg_output = interface_from_core_fp;
         
         for(mb_loop = MB_REG_START; mb_loop < NUMBER_INTERFACE_REGS; mb_loop=mb_loop+1)
           begin
              if(mb_reg_select[mb_loop] == 1'b1)
                begin
-                  mb_reg_rd[mb_loop]  = mb_reg_select[mb_loop] &  mb_reg_rwn;
-                  mb_reg_wr[mb_loop]  = mb_reg_select[mb_loop] & !mb_reg_rwn;
-                  mb_reg_output       = mb_reg_out_w[mb_loop];
+                  mb_reg_rd[mb_loop] = mb_reg_select[mb_loop] &  mb_reg_rwn;
+                  mb_reg_wr[mb_loop] = mb_reg_select[mb_loop] & !mb_reg_rwn;
+                  mb_reg_output      = mb_reg_out_w[mb_loop];
                end
           end
      end

--- a/tests_ok/autosense_venkataramanan_begin.v
+++ b/tests_ok/autosense_venkataramanan_begin.v
@@ -7,7 +7,7 @@ module autosense_venkataramanan_begin(/*AUTOARG*/);
      begin : label
         integer       i, j;
         for (i=0; i< = 3; i = i + 1)
-          vec[i]  = b;
+          vec[i] = b;
      end
    
 endmodule

--- a/tests_ok/autotieoff_assign.v
+++ b/tests_ok/autotieoff_assign.v
@@ -10,10 +10,10 @@ module autotieoff_signed (/*AUTOARG*/
    
    /*AUTOTIEOFF*/
    // Beginning of automatic tieoffs (for this module's unterminated outputs)
-   assign ExtraOut  = 3'h0;
-   assign SubOut  = 3'h0;
-   assign active_low_l  = 4'h0;
-   assign ignored_by_regexp  = 4'h0;
+   assign ExtraOut = 3'h0;
+   assign SubOut = 3'h0;
+   assign active_low_l = 4'h0;
+   assign ignored_by_regexp = 4'h0;
    // End of automatics
    
 endmodule

--- a/tests_ok/autounused.v
+++ b/tests_ok/autounused.v
@@ -26,7 +26,7 @@ module autounused
                                      // End of automatics
                                      1'b0};
    
-   defparam partbuf.width  = width;
+   defparam partbuf.width = width;
    wbuf wbuf
      (// Inputs
       .d                                ({da,db,dc}),

--- a/tests_ok/autowire_godiwala.v
+++ b/tests_ok/autowire_godiwala.v
@@ -26,7 +26,7 @@ module FswArbiter (/*AUTOARG*/
    // ========================
    //  Include parameter File
    // ========================
-   parameter DMAO  = 0;
+   parameter DMAO = 0;
    
 `include "chip_fsw_spec_param.v"
    

--- a/tests_ok/autowire_misalias_bug295.v
+++ b/tests_ok/autowire_misalias_bug295.v
@@ -11,7 +11,7 @@ module foo_autowire_fails (my_interface itf);
    // Beginning of automatic wires (for undeclared instantiated-module outputs)
    wire [2:0] out2;                     // From foobar0 of foobar.v
    // End of automatics
-   assign itf.out2  = out2; // perhaps a namespace collision?
+   assign itf.out2 = out2; // perhaps a namespace collision?
    foobar foobar0
      (/*AUTOINST*/
       // Outputs
@@ -25,7 +25,7 @@ module foo_autowire_works (my_interface itf);
    // Beginning of automatic wires (for undeclared instantiated-module outputs)
    wire [2:0] out2;                     // From foobar0 of foobar.v
    // End of automatics
-   assign itf.out3  = out2;
+   assign itf.out3 = out2;
    foobar foobar0
      (/*AUTOINST*/
       // Outputs

--- a/tests_ok/autowire_myers.v
+++ b/tests_ok/autowire_myers.v
@@ -19,7 +19,7 @@ module test_top;
                    .wireB               (wireB[16:0]));
       end
       else begin
-         assign wireA  = 0;
+         assign wireA = 0;
       end
    endgenerate
 endmodule

--- a/tests_ok/autowire_pkg_bug195.v
+++ b/tests_ok/autowire_pkg_bug195.v
@@ -4,7 +4,7 @@ package testcase_pkg;
    
    typedef int unsigned uint;
    
-   localparam uint SIZE  = 8;
+   localparam uint SIZE = 8;
    
    typedef enum {ENUM1, ENUM2} enum_t;
    
@@ -24,7 +24,7 @@ module testcase_top
    logic [testcase_pkg::SIZE-1:0] sub_in; // From testcase_sub1 of testcase_sub1.v
    logic [testcase_pkg::SIZE-1:0] sub_out;      // From testcase_sub2 of testcase_sub2.v
    // End of automatics
-   assign top_out  = sub_out;
+   assign top_out = sub_out;
    testcase_sub1 testcase_sub1 (.*,
                                 // Outputs
                                 .sub_enum       (sub_enum),      // Implicit .*
@@ -46,8 +46,8 @@ module testcase_sub1
    output logic [testcase_pkg::SIZE-1:0] sub_in
    );
    import testcase_pkg::*;
-   assign sub_enum  = top_enum;
-   assign sub_in  = '1;
+   assign sub_enum = top_enum;
+   assign sub_in = '1;
 endmodule
 
 module testcase_sub2
@@ -57,7 +57,7 @@ module testcase_sub2
    output logic [testcase_pkg::SIZE-1:0] sub_out
    );
    import testcase_pkg::*;
-   assign sub_out  = (sub_enum==ENUM1) ? ~sub_in : sub_in;
+   assign sub_out = (sub_enum==ENUM1) ? ~sub_in : sub_in;
 endmodule
 
 // Local Variables:

--- a/tests_ok/autowire_req_sw.v
+++ b/tests_ok/autowire_req_sw.v
@@ -7,7 +7,7 @@ module autowire_req_sw
    /*AUTOINPUT*/
    );
    
-   assign Bnk0Req  = Cpu0Req;
+   assign Bnk0Req = Cpu0Req;
    
    
 endmodule

--- a/tests_ok/batch_li_parent.v
+++ b/tests_ok/batch_li_parent.v
@@ -6,8 +6,8 @@ module batch_li_parent (/*AUTOARG*/
    input rst;
    input clk;
    
-   parameter WIDTH_0  = 8;
-   parameter WIDTH_1  = 16;
+   parameter WIDTH_0 = 8;
+   parameter WIDTH_1 = 16;
    
    batch_li_child
      #(.WIDTH_1 (WIDTH_0),

--- a/tests_ok/carlson.v
+++ b/tests_ok/carlson.v
@@ -1,15 +1,15 @@
 module x ();
    always @ (/*AUTOSENSE*/bus or in1 or in2 or reset) begin
-      out4  = | bus;
+      out4 = | bus;
       
-      out7  = 1'b0; // pre-initialize output of case so default not needed
+      out7 = 1'b0; // pre-initialize output of case so default not needed
       case (bus[1:0])
-        2'b00: out7  = in1;
-        2'b01: out7  = in2;
-        2'b10: out7  = reset;
+        2'b00: out7 = in1;
+        2'b01: out7 = in2;
+        2'b10: out7 = reset;
 `ifdef BEH
         default: begin
-           out7  = 1'bX; // force VCS simulation to propagate X's from the bus signal
+           out7 = 1'bX; // force VCS simulation to propagate X's from the bus signal
            $display ("\n Error, in module temp, bus[1:0] illegal value of 11\n");
         end
 `endif

--- a/tests_ok/case_question.v
+++ b/tests_ok/case_question.v
@@ -3,14 +3,14 @@ module test ();
    always @(/*AUTOSENSE*/xyz)
      begin
         casex (xyz)
-          4'b???0: r  = 1;
-          4'b??01: r  = 2;
-          4'b?001: r  = 3;
-          default: r  = 4;
+          4'b???0: r = 1;
+          4'b??01: r = 2;
+          4'b?001: r = 3;
+          default: r = 4;
         endcase
      end
    
-   assign x  = y;
+   assign x = y;
    
 endmodule
 

--- a/tests_ok/debug.v
+++ b/tests_ok/debug.v
@@ -9,7 +9,7 @@ module z();
    fgasdfasdfasdfasfdasfd <= p;
    gh                     := h;
    gf                        <=g;
-   ssdf  = 5;
-   f     = zsfdsdf >= f;
+   ssdf = 5;
+   f    = zsfdsdf >= f;
    
 endmodule

--- a/tests_ok/disable.v
+++ b/tests_ok/disable.v
@@ -19,7 +19,7 @@ module foo;
                      // st2
                   end
                join_any // first wins
-               a  = b;
+               a = b;
                disable fork; // kill others
             end // block: body_main_fork
          end // block: body_main_fork

--- a/tests_ok/escape_a.v
+++ b/tests_ok/escape_a.v
@@ -8,7 +8,7 @@ module escape_a (/*AUTOARG*/
    output \o[2] ;
    input  \i&e; ;
    
-   wire \o[10]  = \i&e; ;
+   wire \o[10] = \i&e; ;
    wire \o[2] = \i&e; ;
    
 endmodule

--- a/tests_ok/example.v
+++ b/tests_ok/example.v
@@ -26,7 +26,7 @@ module example (/*AUTOARG*/
               .lower_inb                (lower_inb),
               .lower_ina                (lower_ina));
    always @ (/*AUTOSENSE*/i) begin
-      o  = i;
+      o = i;
    end
 endmodule
 

--- a/tests_ok/for.v
+++ b/tests_ok/for.v
@@ -13,7 +13,7 @@ module lbm
    integer      i;
    always @ (/*AUTOSENSE*/income) begin
       for (i=0; i<32; i=i+1) begin
-         outgo[i]  = income[i];
+         outgo[i] = income[i];
       end
    end
    

--- a/tests_ok/gorfajn.v
+++ b/tests_ok/gorfajn.v
@@ -2,11 +2,11 @@ module x;
    always @(/*autosense*/d32S_CurCcbH or ramS_CcbBaseH or ramS_ccbsizeH)
      begin
         case (ramS_ccbsizeH)
-          2'b00 : ramS_CcbAddH  = {2'b00, d32S_CurCcbH };
-          2'b01 : ramS_CcbAddH  = {1'b0, d32S_CurCcbH, 1'b0};
-          2'b10 : ramS_CcbAddH  = {d32S_CurCcbH, 2'b00};
-          2'b11 : ramS_CcbAddH  = {d32S_CurCcbH, 2'b00}; // unused
+          2'b00 : ramS_CcbAddH = {2'b00, d32S_CurCcbH };
+          2'b01 : ramS_CcbAddH = {1'b0, d32S_CurCcbH, 1'b0};
+          2'b10 : ramS_CcbAddH = {d32S_CurCcbH, 2'b00};
+          2'b11 : ramS_CcbAddH = {d32S_CurCcbH, 2'b00}; // unused
         endcase
-        ramS_CcbAddresH  = {10'h000, ramS_CcbAddH} + ramS_CcbBaseH;
+        ramS_CcbAddresH = {10'h000, ramS_CcbAddH} + ramS_CcbBaseH;
      end
 endmodule

--- a/tests_ok/hangcase.v
+++ b/tests_ok/hangcase.v
@@ -3,57 +3,57 @@
 module hangcase (/*AUTOARG*/);
    
    //
-   assign w_rdat_ena  = ({16{foo[ 0]}} & bar ) |
-                        ({16{foo[ 1]}} & bar ) |
-                        ({16{foo[ 2]}} & bar ) |
-                        ({16{foo[ 3]}} & bar ) |
-                        ({16{foo[ 4]}} & bar ) |
-                        ({16{foo[ 5]}} & bar ) |
-                        ({16{foo[ 6]}} & bar ) |
-                        ({16{foo[ 7]}} & bar ) |
-                        ({16{foo[ 8]}} & bar ) |
-                        ({16{foo[ 9]}} & bar ) |
-                        ({16{foo[10]}} & bar ) |
-                        ({16{foo[11]}} & bar ) |
-                        ({16{foo[12]}} & bar ) |
-                        ({16{foo[13]}} & bar ) |
-                        ({16{foo[14]}} & bar ) |
-                        ({16{foo[15]}} & bar ) ;
+   assign w_rdat_ena = ({16{foo[ 0]}} & bar ) |
+                       ({16{foo[ 1]}} & bar ) |
+                       ({16{foo[ 2]}} & bar ) |
+                       ({16{foo[ 3]}} & bar ) |
+                       ({16{foo[ 4]}} & bar ) |
+                       ({16{foo[ 5]}} & bar ) |
+                       ({16{foo[ 6]}} & bar ) |
+                       ({16{foo[ 7]}} & bar ) |
+                       ({16{foo[ 8]}} & bar ) |
+                       ({16{foo[ 9]}} & bar ) |
+                       ({16{foo[10]}} & bar ) |
+                       ({16{foo[11]}} & bar ) |
+                       ({16{foo[12]}} & bar ) |
+                       ({16{foo[13]}} & bar ) |
+                       ({16{foo[14]}} & bar ) |
+                       ({16{foo[15]}} & bar ) ;
    
    //
-   assign w_rdat_mrk  = ({16{foo[ 0]}} & bar & baz ) |
-                        ({16{foo[ 1]}} & bar & baz ) |
-                        ({16{foo[ 2]}} & bar & baz ) |
-                        ({16{foo[ 3]}} & bar & baz ) |
-                        ({16{foo[ 4]}} & bar & baz ) |
-                        ({16{foo[ 5]}} & bar & baz ) |
-                        ({16{foo[ 6]}} & bar & baz ) |
-                        ({16{foo[ 7]}} & bar & baz ) |
-                        ({16{foo[ 8]}} & bar & baz ) |
-                        ({16{foo[ 9]}} & bar & baz ) |
-                        ({16{foo[10]}} & bar & baz ) |
-                        ({16{foo[11]}} & bar & baz ) |
-                        ({16{foo[12]}} & bar & baz ) |
-                        ({16{foo[13]}} & bar & baz ) |
-                        ({16{foo[14]}} & bar & baz ) |
-                        ({16{foo[15]}} & bar & baz ) ;
+   assign w_rdat_mrk = ({16{foo[ 0]}} & bar & baz ) |
+                       ({16{foo[ 1]}} & bar & baz ) |
+                       ({16{foo[ 2]}} & bar & baz ) |
+                       ({16{foo[ 3]}} & bar & baz ) |
+                       ({16{foo[ 4]}} & bar & baz ) |
+                       ({16{foo[ 5]}} & bar & baz ) |
+                       ({16{foo[ 6]}} & bar & baz ) |
+                       ({16{foo[ 7]}} & bar & baz ) |
+                       ({16{foo[ 8]}} & bar & baz ) |
+                       ({16{foo[ 9]}} & bar & baz ) |
+                       ({16{foo[10]}} & bar & baz ) |
+                       ({16{foo[11]}} & bar & baz ) |
+                       ({16{foo[12]}} & bar & baz ) |
+                       ({16{foo[13]}} & bar & baz ) |
+                       ({16{foo[14]}} & bar & baz ) |
+                       ({16{foo[15]}} & bar & baz ) ;
    
    //
-   assign w_wdat_ena_set  = ({16{ena_set}} & col_dec    );
-   assign w_wdat_ena_clr  = ({16{ena_clr}} & col_dec    );
-   assign w_wdat_mrk_set  = ({16{mrk_set}} & w_rdat_ena );
-   assign w_wdat_mrk_clr  = ({16{mrk_clr}} & col_dec    );
-   assign w_wdat_ena  = (w_rdat_ena & ~w_wdat_ena_clr) | w_wdat_ena_set;
-   assign w_wdat_mrk  = (w_rdat_mrk & ~w_wdat_mrk_clr) | w_wdat_mrk_set;
+   assign w_wdat_ena_set = ({16{ena_set}} & col_dec    );
+   assign w_wdat_ena_clr = ({16{ena_clr}} & col_dec    );
+   assign w_wdat_mrk_set = ({16{mrk_set}} & w_rdat_ena );
+   assign w_wdat_mrk_clr = ({16{mrk_clr}} & col_dec    );
+   assign w_wdat_ena = (w_rdat_ena & ~w_wdat_ena_clr) | w_wdat_ena_set;
+   assign w_wdat_mrk = (w_rdat_mrk & ~w_wdat_mrk_clr) | w_wdat_mrk_set;
    
    //
-   assign w_dat15_ena  = foo[15] ? w_wdat_ena : bar;
+   assign w_dat15_ena = foo[15] ? w_wdat_ena : bar;
    
    //
-   assign w_dat15_mrk  = foo[15] ? w_wdat_mrk : baz;
+   assign w_dat15_mrk = foo[15] ? w_wdat_mrk : baz;
    
    //^^^^ FIX NEWLINE ABOVE HERE
    //
-   assign w_timeout_mrk  = row_check      ?  w_wdat_mrk        : r_timeout_mrk;
+   assign w_timeout_mrk = row_check      ?  w_wdat_mrk        : r_timeout_mrk;
    
 endmodule

--- a/tests_ok/indent_assert.v
+++ b/tests_ok/indent_assert.v
@@ -1,7 +1,7 @@
 module assert_test;
    reg [31:0] whatever2;
    initial begin
-      a  = b;
+      a = b;
       assert(std::randomize(whatever2)  with { whatever2   inside {[10:100]};});
    end
 endmodule // assert_test

--- a/tests_ok/indent_attributes.v
+++ b/tests_ok/indent_attributes.v
@@ -4,7 +4,7 @@ module example(out1, out2, out3);
    /* foobar */ (* LOC = "C15" *) /* jar */ output out2;
    (* LOC = "C16" *)
    output out3;
-   out1  = 1'b1;
-   out2  = 1'b1;
-   out3  = 1'b1;
+   out1 = 1'b1;
+   out2 = 1'b1;
+   out3 = 1'b1;
 endmodule

--- a/tests_ok/indent_bracket.v
+++ b/tests_ok/indent_bracket.v
@@ -6,7 +6,7 @@ module foo
    output [63:0] data_out,
    output        ctl_out);
    
-   assign data_out  = data_in[1] ? data_in[63:0]
-                      :            64'h0;
+   assign data_out = data_in[1] ? data_in[63:0]
+                     :            64'h0;
    
 endmodule

--- a/tests_ok/indent_class.v
+++ b/tests_ok/indent_class.v
@@ -6,7 +6,7 @@ class temp;
    extern function test();
    extern function test2();
    function foo();
-      foo  = 1;
+      foo = 1;
    endfunction // foo
    extern function test3();
    reg [31:0] b;
@@ -24,7 +24,7 @@ module foo;
    reg [1:0] b;
    
    initial begin
-      b  = `vmm_channel(a);
+      b = `vmm_channel(a);
    end // initial begin
 endmodule // foo
 

--- a/tests_ok/indent_clocking.v
+++ b/tests_ok/indent_clocking.v
@@ -1,10 +1,10 @@
 module t;
    default clocking @(posedge clk);
    begin
-      a  = 8;
+      a = 8;
    end
    property foo (a)
-     a  = b;
+     a = b;
    endproperty
    cover property (prop) $display("**COVERAGE**");
    assert property (foo) a;

--- a/tests_ok/indent_clockingblock.v
+++ b/tests_ok/indent_clockingblock.v
@@ -1,5 +1,5 @@
 class mipsbfm_trans extends vmm_data;
-   static vmm_log log  = new ("mipsbfm_trans", "class") ;
+   static vmm_log log = new ("mipsbfm_trans", "class") ;
    logic [31:0] addr, data, mask, op;
    function new();
       super.new(this.log);

--- a/tests_ok/indent_constraint.v
+++ b/tests_ok/indent_constraint.v
@@ -98,7 +98,7 @@ module fool;
    
    always @(posedge clk) begin
       if(!M_select)
-        xferCount <  = 8'd0;
+        xferCount < = 8'd0;
       else
         case (condition[1 :0])
           2'b00 : xferCount <= xferCount;
@@ -110,7 +110,7 @@ module fool;
    // But not this :
    always @(posedge clk) begin
       if(!M_select)
-        xferCount <  = 8'd0;
+        xferCount < = 8'd0;
       else
         case ({M_seqAddr,OPB_xferAck})
           2'b00 : xferCount <= xferCount;
@@ -124,9 +124,9 @@ endmodule // fool
 
 module foo;
    initial begin
-      k  = 10;
+      k = 10;
       std::randomize(delay) with { (delay>=1000 && delay<=3000); };
-      j  = 9;
+      j = 9;
    end
 endmodule // foo
 

--- a/tests_ok/indent_constraint3.v
+++ b/tests_ok/indent_constraint3.v
@@ -24,7 +24,7 @@ class data;
    }
    
    function new();
-      data1  = 0;
-      data2  = 78;
+      data1 = 0;
+      data2 = 78;
    endfunction // new
 endclass // data

--- a/tests_ok/indent_covergroup.v
+++ b/tests_ok/indent_covergroup.v
@@ -7,20 +7,20 @@ module coverage;
       c : coverpoint color;
    endgroup // foo
    
-   foo  = bar;
+   foo = bar;
    
    sequence bar
-     b  = c;
+     b = c;
    endsequence // bar
-   j  = taskt;
+   j = taskt;
    function foo;
       begin
-         foo  = 1;
+         foo = 1;
       end
    endfunction // foo
    
    randsequence bar
-     b  = c;
+     b = c;
    endsequence // bar
    
    case (foo)

--- a/tests_ok/indent_decl-1.v
+++ b/tests_ok/indent_decl-1.v
@@ -19,9 +19,9 @@ module soft_rst
    
    reg [1:0] state;
    
-   reg [1:0] IDLE  = 2'h0,
-             HALT  = 2'h1,
-             RST   = 2'h2,
-             DONE  = 2'h3;
+   reg [1:0] IDLE = 2'h0,
+             HALT = 2'h1,
+             RST  = 2'h2,
+             DONE = 2'h3;
    
 endmodule // soft_rst

--- a/tests_ok/indent_directives.v
+++ b/tests_ok/indent_directives.v
@@ -33,30 +33,30 @@ module foo;
    reg      a,b;
 `ifdef A
    always @(a) begin
-      b  = a; // asfSDfsdfsasa
-      b  = a; // asfSDfsdfsasa
-      b  = a; // asfSDfsdfsasa      //
-      b  = a; // asfSDfsdfsasa      //
-      b  = a; // asfSDfsdfsasa      //
-      b  = a; // asfSDfsdfsasa      //
-      b  = a; // asfSDfsdfsasa      //
-      b  = a; // asfSDfsdfsasa      //
-      b  = a; // asfSDfsdfsasa      //
+      b = a; // asfSDfsdfsasa
+      b = a; // asfSDfsdfsasa
+      b = a; // asfSDfsdfsasa      //
+      b = a; // asfSDfsdfsasa      //
+      b = a; // asfSDfsdfsasa      //
+      b = a; // asfSDfsdfsasa      //
+      b = a; // asfSDfsdfsasa      //
+      b = a; // asfSDfsdfsasa      //
+      b = a; // asfSDfsdfsasa      //
    end
 `elsif B
    always @(b) begin
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa      //
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa      //
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa      //
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa
-      a  = b; // asfSDfsdfsasa      //
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa      //
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa      //
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa      //
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa
+      a = b; // asfSDfsdfsasa      //
    end
 `else // !`elsif B
    always @(a or b) begin

--- a/tests_ok/indent_fork_join_any.v
+++ b/tests_ok/indent_fork_join_any.v
@@ -6,20 +6,20 @@ module fork_join_any;
                begin
                end
             join_any
-            a  = b;
+            a = b;
             disable fork;
             blah;
             wait fork;
             blah;
          end
       join_any
-      foo  = bar;
+      foo = bar;
    end // initial fork
 endmodule // fork_join_any
 
 class x;
    task y;
-      a  = b;
+      a = b;
       wait fork;
       $display("I'm indented too far");
    endtask // y

--- a/tests_ok/indent_function.v
+++ b/tests_ok/indent_function.v
@@ -3,7 +3,7 @@ module t;
 endmodule
 class C;
    function int f();
-      f  = 17;
+      f = 17;
    endfunction
    extern function int g();
    virtual function int f();
@@ -16,7 +16,7 @@ class C;
       $display("a of f is %d, g is %d", a.f(),a.g());
    end
    function int C::g();
-      g  = 18;
+      g = 18;
    endfunction // g
    // pure virtual functions have no endfunction.
 endclass // C

--- a/tests_ok/indent_generate.v
+++ b/tests_ok/indent_generate.v
@@ -6,7 +6,7 @@ module test();
    generate
       for(i=0; i<4; i=i+1) begin:a
          always @(*) begin
-            x[i]  = 1;
+            x[i] = 1;
          end
          wire y = 0;
       end

--- a/tests_ok/indent_immediate_assertion.sv
+++ b/tests_ok/indent_immediate_assertion.sv
@@ -12,7 +12,7 @@ module tb;
    always @(abcd) begin
       
       // simple immediate assert statement
-      assert (xyz) a  = b;
+      assert (xyz) a = b;
       
       // deferred immediate cover statement w/ #0
       if(x)

--- a/tests_ok/indent_importfunction.v
+++ b/tests_ok/indent_importfunction.v
@@ -1,8 +1,8 @@
 module toto (input logic dummy);
    import "DPI-C" pure function real fabs (input real a);
    import "DPI-C" context function real fcons (input real a);
-   import "DPI-C" string_sv2c  = task string();
-   import "DPI-C" int_sv2c  = task intsv2c();
-   import "DPI-C" context int_sv2c  = task intsv2cont();
+   import "DPI-C" string_sv2c = task string();
+   import "DPI-C" int_sv2c = task intsv2c();
+   import "DPI-C" context int_sv2c = task intsv2cont();
    logic a; // wrong indentation
 endmodule // wrong indentation

--- a/tests_ok/indent_lineup_inlists.v
+++ b/tests_ok/indent_lineup_inlists.v
@@ -17,9 +17,9 @@ module soft_rst (
    
    reg [1:0] state;
    
-   localparam [1:0] IDLE  = 2'h0,
-     HALT  = 2'h1,
-     RST   = 2'h2,
-     DONE  = 2'h3;
+   localparam [1:0] IDLE = 2'h0,
+     HALT = 2'h1,
+     RST  = 2'h2,
+     DONE = 2'h3;
    
 endmodule // soft_rst

--- a/tests_ok/indent_lineup_mode_all.v
+++ b/tests_ok/indent_lineup_mode_all.v
@@ -10,6 +10,24 @@ module test (pci_ack, reg_wr, reg_sel, clk,  rst);
       x       <= y;
       longish <= alsolongish;
    end
+   // Only blocking assignments
+   initial begin
+      lorem = 0;
+      ip    = 1;
+      sum   = 2;
+   end
+   // Only non-blocking assignments
+   initial begin
+      dolor <= 0;
+      sit   <= 1;
+      amet  <= 2;
+   end
+   // Mix of blocking and non-blocking assignments
+   initial begin
+      consectetur  = 0;
+      adipiscing  <= 1;
+      elit        <= 2;
+   end
    
 endmodule
 

--- a/tests_ok/indent_mailbox.v
+++ b/tests_ok/indent_mailbox.v
@@ -5,9 +5,9 @@ class Driver;
    virtual   Rx_if Rx;
    
    function new(mailbox mbox, int id, virtual Rx_if.TB Rx);
-      this.mbox  = mbox;
-      this.id    = i;
-      this.Rx    = Rx;
+      this.mbox = mbox;
+      this.id   = i;
+      this.Rx   = Rx;
    endfunction // new
 endclass // Driver
 

--- a/tests_ok/indent_named_assert.v
+++ b/tests_ok/indent_named_assert.v
@@ -4,6 +4,6 @@ module test;
    endproperty : p_test
    assert property (p_test);
    a_test : assert property (p_test);
-   a  = b; // this and following lines are not properly indented
+   a = b; // this and following lines are not properly indented
    foo;
 endmodule // test

--- a/tests_ok/indent_ovm.v
+++ b/tests_ok/indent_ovm.v
@@ -7,8 +7,8 @@ class simple_item extends ovm_sequence_item;
    constraint c2 { data < 16'h1000; }
    // OVM automation macros for general objects
    `ovm_object_utils_begin(simple_item)
-      a  = b;
-      c  = d;
+      a = b;
+      c = d;
       `ovm_field_int(addr, OVM_ALL_ON)
       `ovm_field_int(data, OVM_ALL_ON)
       `ovm_field_int(delay, OVM_ALL_ON)

--- a/tests_ok/indent_property.v
+++ b/tests_ok/indent_property.v
@@ -23,7 +23,7 @@ module foo();
    
    
    property p_3;
-      a  = > ##3 !a;
+      a = > ##3 !a;
       a |=> ##1 !a;
       a |-> ##2 !a;
    endproperty

--- a/tests_ok/indent_randcase.v
+++ b/tests_ok/indent_randcase.v
@@ -5,11 +5,11 @@ module aa;
    initial begin
       randcase
         10 : begin
-           a  = 1;
+           a = 1;
         end
         15 : begin
-           b  = 0;
-           c  = 5;
+           b = 0;
+           c = 5;
         end
       endcase // randcase
       

--- a/tests_ok/indent_struct.v
+++ b/tests_ok/indent_struct.v
@@ -1,7 +1,7 @@
 module foo;
    
-   a  = { g + c; };
-   a  = c;
+   a = { g + c; };
+   a = c;
    
    typedef struct {
       reg        r;

--- a/tests_ok/indent_task.v
+++ b/tests_ok/indent_task.v
@@ -3,19 +3,19 @@ module foo;
    // for each additional in-air txmacphy byte
    task nextTxByte();
       TxByteCnt++;
-      TxLastByteTime  = $time;
+      TxLastByteTime = $time;
    endtask // nextTxByte
    task automatic blah();
       t;
    endtask // blah
    function static foo();
-      foo  = 1;
+      foo = 1;
    endfunction // foo
    // start counting when txmacphy sees first in-air byte
    task firstTxByte();
-      TxByteCnt        = 1;
-      TxFirstByteTime  = $time;
-      TxLastByteTime   = $time;
+      TxByteCnt       = 1;
+      TxFirstByteTime = $time;
+      TxLastByteTime  = $time;
    endtask // firstTxByte
    
    // outputs the overall performance of the RX path in Mbps (MBits per second)
@@ -23,9 +23,9 @@ module foo;
       integer ibps;
       real    Mbps;
       if( RxByteCnt && systemTop.intMonitor.frgRxedCnt >= 2 ) begin
-         ibps  = 
-                 (RxByteCnt*8*1000000000)/(RxLastByteTime-RxFirstByteTime);
-         Mbps  = ibps/1000000;
+         ibps = 
+                (RxByteCnt*8*1000000000)/(RxLastByteTime-RxFirstByteTime);
+         Mbps = ibps/1000000;
          $display("%t: %s - RX average performance: %fMbps (Mbits/sec)",
                   $time, myName, Mbps );
       end
@@ -38,7 +38,7 @@ endmodule // foo
 
 class a;
    virtual function void foo();
-      foo  = 2;
+      foo = 2;
    endfunction // void
    extern function void bar();
    function fred();

--- a/tests_ok/indent_unique_case-2.v
+++ b/tests_ok/indent_unique_case-2.v
@@ -2,18 +2,18 @@ module testmod ();
    always_comb begin
       unique case (eeee)
         ZERO[1:0] : begin
-           a  = 1;
+           a = 1;
         end // case: ZERO[1:0]
         
         ONE[1:0] : begin
-           a  = 1;
+           a = 1;
         end // case: ONE[1:0]
         
         TWO[1:0] : begin
-           a  = 1;
+           a = 1;
         end // case: TWO[1:0]
         THREE[1:0] : begin
-           a  = 1;
+           a = 1;
         end // case: THREE[1:0]
       endcase // unique case (eeee)
    end // always_comb

--- a/tests_ok/indent_unique_case.v
+++ b/tests_ok/indent_unique_case.v
@@ -7,29 +7,29 @@ module foo;
       
       unique case(vlcnum)
         0 : unique case(in.value1)
-                     0    : out          = 1; 1 : out = 3; 2 : out = 3; 3 : out = 4;
-                     4    : out          = 4; 5 : out = 5; 6 : out = 5; 7 : out = 6;
-                     8    : out          = 6; 9 : out = 7; 10: out = 7; 11: out = 8;
-                     12           : out  = 8; 13: out = 9; 14: out = 9; 15: out = 9;
+                     0    : out         = 1; 1 : out = 3; 2 : out = 3; 3 : out = 4;
+                     4    : out         = 4; 5 : out = 5; 6 : out = 5; 7 : out = 6;
+                     8    : out         = 6; 9 : out = 7; 10: out = 7; 11: out = 8;
+                     12           : out = 8; 13: out = 9; 14: out = 9; 15: out = 9;
                    endcase
         1         :
           unique
           case(in.value1)
-            0             : out  = 3;
-            1     : out          = 3;
-            2     : out          = 3;
-            3     : out          = 3;
-            4     : out          = 3;
-            5     : out          = 4;
-            6     : out          = 4;
-            7     : out          = 4;
-            8     : out          = 4;
-            9     : out          = 5;
-            10   : out           = 5;
-            11   : out           = 6;
-            12   : out           = 6;
-            13   : out           = 6;
-            14   : out           = 6;
+            0             : out = 3;
+            1     : out         = 3;
+            2     : out         = 3;
+            3     : out         = 3;
+            4     : out         = 3;
+            5     : out         = 4;
+            6     : out         = 4;
+            7     : out         = 4;
+            8     : out         = 4;
+            9     : out         = 5;
+            10   : out          = 5;
+            11   : out          = 6;
+            12   : out          = 6;
+            13   : out          = 6;
+            14   : out          = 6;
           endcase // case (in.value1)
       endcase // case (in.value1)
    end

--- a/tests_ok/indent_uvm.v
+++ b/tests_ok/indent_uvm.v
@@ -7,8 +7,8 @@ class simple_item extends uvm_sequence_item;
    constraint c2 { data < 16'h1000; }
    // UVM automation macros for general objects
    `uvm_object_utils_begin(simple_item)
-      a  = b;
-      c  = d;
+      a = b;
+      c = d;
       `uvm_field_int(addr, UVM_ALL_ON)
       `uvm_field_int(data, UVM_ALL_ON)
       `uvm_field_int(delay, UVM_ALL_ON)

--- a/tests_ok/inject_first.v
+++ b/tests_ok/inject_first.v
@@ -8,10 +8,10 @@ module ex_inject (i, o,/*AUTOARG*/
    
    // Ok:
    always @ (/*AS*/i or j)
-     o             = i | j;
+     o            = i | j;
    // No change:
-   always @ (j) o  = i | j;
-   always @ (j or i or p) o  = i | j;
+   always @ (j) o = i | j;
+   always @ (j or i or p) o = i | j;
    // Instant
    
    autoinst_lopaz_srpad pad

--- a/tests_ok/inject_inst_empty_ports.v
+++ b/tests_ok/inject_inst_empty_ports.v
@@ -23,5 +23,5 @@ module register (
      if (!rst_n) q <= '0;
    else        q <= d;
    
-   assign qb  = ~q;
+   assign qb = ~q;
 endmodule

--- a/tests_ok/inject_inst_param.v
+++ b/tests_ok/inject_inst_param.v
@@ -1,5 +1,5 @@
 module inject_inst_param;
-   parameter WIDTH  = 8;
+   parameter WIDTH = 8;
    logic [WIDTH-1:0] q;
    logic [WIDTH-1:0] d;
    logic             clk, rst_n;

--- a/tests_ok/lineup.v
+++ b/tests_ok/lineup.v
@@ -1,2 +1,2 @@
 module ocnSwitchClockGen(output reg ocnSwitchClock);
-   parameter   ocnSwitchClockPeriod  = 2000;
+   parameter   ocnSwitchClockPeriod = 2000;

--- a/tests_ok/mac_autosense_dot.v
+++ b/tests_ok/mac_autosense_dot.v
@@ -3,7 +3,7 @@
 module x;
    
    always @ (/*AS*/top.agc_tool.adc_dta_i or top.agc_tool.adc_preagc_dta_i) begin
-      agctoolerr  = top.agc_tool.adc_dta_i / top.agc_tool.adc_preagc_dta_i;
+      agctoolerr = top.agc_tool.adc_dta_i / top.agc_tool.adc_preagc_dta_i;
    end
    
 endmodule

--- a/tests_ok/morrison.v
+++ b/tests_ok/morrison.v
@@ -5,7 +5,7 @@ module test ();
    always @(/*AUTOSENSE*/r or x)
      begin
         casex(x)
-          5: d  = {r, `XYZ };
+          5: d = {r, `XYZ };
         endcase
      end
    

--- a/tests_ok/params_multiline_msg618.v
+++ b/tests_ok/params_multiline_msg618.v
@@ -4,7 +4,7 @@ module testMultiLineParams (/*AUTOARG*/) ;
    
    // expect AUTOSENSE to be comboIn only, no params
    always @ ( /*AUTOSENSE*/comboIn) begin
-      comboOout  = param1 & param2 & param3 & comboIn;
+      comboOout = param1 & param2 & param3 & comboIn;
    end
    
 endmodule // foo

--- a/tests_ok/params_multiline_msg618_inc.vh
+++ b/tests_ok/params_multiline_msg618_inc.vh
@@ -1,6 +1,6 @@
 parameter
   // full line comment
-  param1  = 1'b1,  // trailing comment
-  param2  = 1'b0,  /* trailing comment */
+  param1 = 1'b1,  // trailing comment
+  param2 = 1'b0,  /* trailing comment */
          // full line comment
-  param3  = 1'b1;
+  param3 = 1'b1;

--- a/tests_ok/property_test.v
+++ b/tests_ok/property_test.v
@@ -13,7 +13,7 @@ module test();
    
    
    // Create a test clock
-   always #01.8 test_clk  = ~test_clk;
+   always #01.8 test_clk = ~test_clk;
    
    //**********************************************************************
    // Testing.

--- a/tests_ok/set_membership.sv
+++ b/tests_ok/set_membership.sv
@@ -10,7 +10,7 @@ module top;
    initial begin
       $display ("---- A or B inside {0,8'hFF} ----");
       for (i = 1; i<=5; i++) begin
-         req  = new();
+         req = new();
          assert( a() with {A} );
          req.randomize()
            with
@@ -24,7 +24,7 @@ module top;
          $display ("---- op  inside [add_op : mul_op] ----");
          
          for (i = 1; i<=10; i++) begin
-            req  = new();
+            req = new();
             assert(
                    req.randomize() with
                    {

--- a/tests_ok/sol_asense.v
+++ b/tests_ok/sol_asense.v
@@ -30,29 +30,29 @@ module x (/*AUTOARG*/
       
       for (i=0; i<=5; i=i+1) begin
          
-         MTEMP1[3:0]  = {MIERHW[i*3+3],
-                         MIERHW[i*3+2],
-                         MIERHW[i*3+1],
-                         MIERHW[i*3+0]};
+         MTEMP1[3:0] = {MIERHW[i*3+3],
+                        MIERHW[i*3+2],
+                        MIERHW[i*3+1],
+                        MIERHW[i*3+0]};
          
          casex (MTEMP1)
            
-           4'b0000: MTEMP2  = 4'b0101; // +0
-           4'b0001: MTEMP2  = 4'b0001; // +1
-           4'b0010: MTEMP2  = 4'b0001; // +1
-           4'b0011: MTEMP2  = 4'b0010; // +2
-           4'b0100: MTEMP2  = 4'b0010; // +2
-           4'b0101: MTEMP2  = 4'b0100; // +3
-           4'b0110: MTEMP2  = 4'b0100; // +3
-           4'b0111: MTEMP2  = 4'b1000; // +4
-           4'b1000: MTEMP2  = 4'b0111; // -4
-           4'b1001: MTEMP2  = 4'b1011; // -3
-           4'b1010: MTEMP2  = 4'b1011; // -3
-           4'b1011: MTEMP2  = 4'b1101; // -2
-           4'b1100: MTEMP2  = 4'b1101; // -2
-           4'b1101: MTEMP2  = 4'b1110; // -1
-           4'b1110: MTEMP2  = 4'b1110; // -1
-           4'b1111: MTEMP2  = 4'b1010; // -0
+           4'b0000: MTEMP2 = 4'b0101; // +0
+           4'b0001: MTEMP2 = 4'b0001; // +1
+           4'b0010: MTEMP2 = 4'b0001; // +1
+           4'b0011: MTEMP2 = 4'b0010; // +2
+           4'b0100: MTEMP2 = 4'b0010; // +2
+           4'b0101: MTEMP2 = 4'b0100; // +3
+           4'b0110: MTEMP2 = 4'b0100; // +3
+           4'b0111: MTEMP2 = 4'b1000; // +4
+           4'b1000: MTEMP2 = 4'b0111; // -4
+           4'b1001: MTEMP2 = 4'b1011; // -3
+           4'b1010: MTEMP2 = 4'b1011; // -3
+           4'b1011: MTEMP2 = 4'b1101; // -2
+           4'b1100: MTEMP2 = 4'b1101; // -2
+           4'b1101: MTEMP2 = 4'b1110; // -1
+           4'b1110: MTEMP2 = 4'b1110; // -1
+           4'b1111: MTEMP2 = 4'b1010; // -0
            
          endcase
          
@@ -61,7 +61,7 @@ module x (/*AUTOARG*/
       {MBOOTH_P[i*4+3],
        MBOOTH_P[i*4+2],
        MBOOTH_P[i*4+1],
-       MBOOTH_P[i*4+0]}  = MTEMP2[3:0];
+       MBOOTH_P[i*4+0]} = MTEMP2[3:0];
       
    end
    
@@ -77,12 +77,12 @@ module x (/*AUTOARG*/
             or MULTSHCYC or MULTUSCYC)  begin
       
       case (1'b1)
-        CEIopMADH_E_D2_R: HI_P  = MCLA;
-        CEIopMAZH_E_D2_R: HI_P  = MCLA;
-        DIV2HI:           HI_P  = DDATAH;
-        MULTUSCYC:        HI_P  = MCLA;
-        MULTSHCYC:        HI_P  = `DMCLASH;
-        default:          HI_P  = `DCONST;
+        CEIopMADH_E_D2_R: HI_P = MCLA;
+        CEIopMAZH_E_D2_R: HI_P = MCLA;
+        DIV2HI:           HI_P = DDATAH;
+        MULTUSCYC:        HI_P = MCLA;
+        MULTSHCYC:        HI_P = `DMCLASH;
+        default:          HI_P = `DCONST;
       endcase
    end
 endmodule

--- a/tests_ok/src_frag.vs
+++ b/tests_ok/src_frag.vs
@@ -68,7 +68,7 @@ module src_frag (
    semaphore          sm;
    
    
-   defparam v_lg  = 56;
+   defparam v_lg = 56;
    
 endmodule // src_frag
 

--- a/tests_ok/testcases.v
+++ b/tests_ok/testcases.v
@@ -16,7 +16,7 @@ module testmodule (/*AUTOARG*/
    
    function [2:0] ffs;
       input [2:0] in;
-      ffs  = in & 3'b010;
+      ffs = in & 3'b010;
    endfunction
    
    task show;
@@ -54,9 +54,9 @@ module testmodule (/*AUTOARG*/
    
    always @(/*AUTOSENSE*/in1 or in2 or in3 or in4) begin
       :ignore_label
-      out1  = $realtobits(in1);
-      out2  = ffs(in1 | (in2) );
-      out3  = ffs /*check*/ (in2);
+      out1 = $realtobits(in1);
+      out2 = ffs(in1 | (in2) );
+      out3 = ffs /*check*/ (in2);
       $display ("chk ", in1);
       show (in4);
       if (|in3) out4=1; else out4=0;
@@ -77,42 +77,42 @@ module testmodule (/*AUTOARG*/
    
 `define temp 3'b010
    always @(/*AUTOSENSE*/in3) begin
-      outb6  = (in3 == `temp);
+      outb6 = (in3 == `temp);
    end
    
    integer   i;
    reg [2:0] out7;
    always @ (/*AUTOSENSE*/in1) begin
       for (i=0; i<3; i=i+1) begin
-         assign out7[i]  = ~in1[i];
+         assign out7[i] = ~in1[i];
       end
    end
    
    always @ (/*AUTOSENSE*/in1 or in2 or in3) begin
-      {outw1 [ffs(in1)], outw2 [ffs(in2)]}  = 2'b10;
-      {outw3[(|in1)?in2:in3], outb2}        = 2'b10;
+      {outw1 [ffs(in1)], outw2 [ffs(in2)]} = 2'b10;
+      {outw3[(|in1)?in2:in3], outb2}       = 2'b10;
    end
    
-   initial memarry[0]  = in2;
+   initial memarry[0] = in2;
    always @ (/*AUTOSENSE*/ /*memory or*/ in1) begin
       $display (memarry[in1]);
    end
    
    always @(/*AUTOSENSE*/in1 or in2)
      casex(in1[1:0]) // synopsys full_case parallel_case
-       2'b01 :  out8  = 3'b001;
-       2'b10 :  out8  = 3'b010;
+       2'b01 :  out8 = 3'b001;
+       2'b10 :  out8 = 3'b010;
        default
-         out8  = in2;
+         out8 = in2;
      endcase
    
-   parameter READ  = 3'b111,
+   parameter READ = 3'b111,
      //WRITE = 3'b111,
-     CFG  = 3'b010;
+     CFG = 3'b010;
    //supply1   one;
    
    always @(/*AUTOSENSE*/in1 or in2) begin
-      outb7  = (in1==READ) || (in2==CFG);
+      outb7 = (in1==READ) || (in2==CFG);
    end
    
    always @(/*AUTOSENSE*/in1) begin
@@ -125,28 +125,28 @@ module testmodule (/*AUTOARG*/
      begin: label_no_sense
         casex (outw1) // synopsys full_case parallel_case
           {`shift_instr,3'bxxx}:
-            outb3             = in3[0];
-          8'b00001x10: outb3  = in4[0];
+            outb3            = in3[0];
+          8'b00001x10: outb3 = in4[0];
           8'b00110011:
             if (in5[0])
-              outb3  = in1[0];
+              outb3 = in1[0];
             else
-              outb3  = in2[1];
+              outb3 = in2[1];
           default
-            outb3  = in4[0];
+            outb3 = in4[0];
         endcase
      end
    
-   parameter WIDLE  = 0;                // No Manual Write Burst
+   parameter WIDLE = 0;         // No Manual Write Burst
    
    always @ (/*AUTOSENSE*/in1 or in2 or in3 or in4) begin
       case(1'b1)
         in2[WIDLE]:
-          outb4  = in1[0];
+          outb4 = in1[0];
         in3[in4]:
-          outb4  = in1[0];
+          outb4 = in1[0];
         default:
-          outb4  = 1'bx;
+          outb4 = 1'bx;
       endcase
    end
    
@@ -162,16 +162,16 @@ module darren_jones_2 (/*AUTOARG*/
    output [1:0] next_WSTATE;
    reg [1:0]    next_WSTATE;
    parameter
-     WIDLE  = 0,                // No Manual Write Burst
-     WCB0   = 1;                // 1st of the 4 Manual Write Burst
+     WIDLE = 0,         // No Manual Write Burst
+     WCB0  = 1;         // 1st of the 4 Manual Write Burst
    
    always @ (/*AUTOSENSE*/WSTATE) begin
-      next_WSTATE  = 2'b0;
+      next_WSTATE = 2'b0;
       case (1'b1)
         WSTATE[WIDLE]:
-          next_WSTATE[1'b0]  = 1'b1;
+          next_WSTATE[1'b0] = 1'b1;
         WSTATE[WCB0]:
-          next_WSTATE[WCB0]  = 1'b1;
+          next_WSTATE[WCB0] = 1'b1;
       endcase
    end
 endmodule
@@ -187,30 +187,30 @@ module darren_jones_3 (/*AUTOARG*/
    reg         var1;
    
    parameter
-     IDLE  = 1,
-     CAS1  = 2;
+     IDLE = 1,
+     CAS1 = 2;
    
    always @(/*AUTOSENSE*/state) begin
       case (1'b1)
         state[IDLE] : begin
-           var1  = 1'b1;
+           var1 = 1'b1;
         end
         state[CAS1] : begin
-           var1  = 1'b1;
+           var1 = 1'b1;
         end
         default : begin
-           var1  = 1'b1;
+           var1 = 1'b1;
         end
       endcase
    end
    
    always @(/*AUTOSENSE*/add or lo or mc_32pff or mc_losel or slo or var1) begin
       case(mc_losel)
-        6'b000001:  lo_mux  = mc_32pff ? {add[39:0],lo[31:8]} :
-                              {add[7:0],lo[63:8]};
+        6'b000001:  lo_mux = mc_32pff ? {add[39:0],lo[31:8]} :
+                             {add[7:0],lo[63:8]};
         
-        6'b010000:  lo_mux  = lo;
-        6'b100000:  lo_mux  = var1 ? IDLE : slo;
+        6'b010000:  lo_mux = lo;
+        6'b100000:  lo_mux = var1 ? IDLE : slo;
       endcase
    end // always @ (...
    

--- a/tests_ok/two_modules.v
+++ b/tests_ok/two_modules.v
@@ -16,7 +16,7 @@ module appendix1 (/*AUTOARG*/
    /*AUTOWIRE*/
    
    always @ (/*AUTOSENSE*/i) begin
-      z  = i;
+      z = i;
    end
 endmodule
 

--- a/tests_ok/v2k_localparam.v
+++ b/tests_ok/v2k_localparam.v
@@ -2,13 +2,13 @@
 // 2001 Parameter Style
 module v2k_localparam;
    
-   localparam X  = 10;
-   parameter  Y  = 10;
+   localparam X = 10;
+   parameter  Y = 10;
    
    reg z;
    
    always @ (/*AS*/) begin
-      z  = X | Y;
+      z = X | Y;
    end
    
 endmodule

--- a/tests_ok/v2k_signed_kundsen.v
+++ b/tests_ok/v2k_signed_kundsen.v
@@ -15,7 +15,7 @@ module foo_bar (/*AUTOARG*/
    reg signed [15:0]     result;
    
    always @ (/*AS*/rst) begin
-      result  = 32'sh22 | rst;
+      result = 32'sh22 | rst;
    end
    
 endmodule // foo_bar

--- a/tests_ok/v2k_typedef_yee_sub1.v
+++ b/tests_ok/v2k_typedef_yee_sub1.v
@@ -18,9 +18,9 @@ module v2k_typedef_yee_sub1
       pixel_ff <= sub1_in_pixel;
    end
    
-   assign sub1_out_pixel  = pixel_ff;
-   assign sub1_to_sub2  = '1;
-   assign sub1_to_sub2_and_top  = '1;
+   assign sub1_out_pixel = pixel_ff;
+   assign sub1_to_sub2 = '1;
+   assign sub1_to_sub2_and_top = '1;
    
 endmodule
 

--- a/tests_ok/v2k_typedef_yee_sub2.v
+++ b/tests_ok/v2k_typedef_yee_sub2.v
@@ -25,8 +25,8 @@ module v2k_typedef_yee_sub2
       sub1_to_sub2_ff <= sub1_to_sub2;
    end
    
-   assign sub2_out_pixel  = pixel_ff;
-   assign ready  = sub1_to_sub2_ff;
+   assign sub2_out_pixel = pixel_ff;
+   assign ready = sub1_to_sub2_ff;
    
 endmodule
 

--- a/tests_ok/verilint_113.v
+++ b/tests_ok/verilint_113.v
@@ -20,7 +20,7 @@ module cdl_io (/*AUTOARG*/
    task direct_write;
       input val;
       begin
-         `TOPSIG  = val;
+         `TOPSIG = val;
       end
    endtask
 endmodule

--- a/tests_ok/wasson.v
+++ b/tests_ok/wasson.v
@@ -5,7 +5,7 @@ module foo(__a,b);
    output b;
    
    always @(/*AUTOSENSE*/__a or `FOO) begin
-      b  = __a ^ `FOO ;
+      b = __a ^ `FOO ;
    end
    
 endmodule

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -4034,7 +4034,7 @@ With optional ARG, remove existing end of line comments."
           (progn
             (if (or (eq 'all verilog-auto-lineup)
                     (eq 'assignments verilog-auto-lineup))
-                (verilog-pretty-expr t "\\(<\\|:\\)?=" ))
+                (verilog-pretty-expr :quiet))
             (newline))
         (forward-line 1))
       ;; Indent next line
@@ -6976,106 +6976,97 @@ Be verbose about progress unless optional QUIET set."
 	      (forward-line 1))
 	    (unless quiet (message "")))))))
 
-(defun verilog-pretty-expr (&optional quiet _myre)
-  "Line up expressions around point, optionally QUIET with regexp _MYRE ignored."
+(defun verilog-pretty-expr (&optional quiet)
+  "Line up expressions around point.
+If QUIET is non-nil, do not print messages showing the progress of line-up."
   (interactive)
-  (if (not (verilog-in-comment-or-string-p))
-      (save-excursion
-        (let ( (rexp (concat "^\\s-*" verilog-complete-reg))
-               (rexp1 (concat "^\\s-*" verilog-basic-complete-re)))
-          (beginning-of-line)
-          (if (and (not (looking-at rexp ))
+  (unless (verilog-in-comment-or-string-p)
+    (save-excursion
+      (let ((regexp (concat "^\\s-*" verilog-complete-reg))
+            (regexp1 (concat "^\\s-*" verilog-basic-complete-re)))
+        (beginning-of-line)
+        (when (and (not (looking-at regexp))
                    (looking-at verilog-assignment-operation-re)
                    (save-excursion
                      (goto-char (match-end 2))
                      (and (not (verilog-in-attribute-p))
                           (not (verilog-in-parameter-p))
                           (not (verilog-in-comment-or-string-p)))))
-              (let* ((here (point))
-                     (e) (r)
-                     (start
-                      (progn
-                        (beginning-of-line)
-                        (setq e (point))
-                        (verilog-backward-syntactic-ws)
-                        (beginning-of-line)
-                        (while (and (not (looking-at rexp1))
-                                    (looking-at verilog-assignment-operation-re)
-                                    (not (bobp))
-                                    )
-                          (setq e (point))
-                          (verilog-backward-syntactic-ws)
+          (let* ((start (save-excursion ; BOL of the first line of the assignment block
                           (beginning-of-line)
-                          ) ;Ack, need to grok `define
-                        e))
-                     (end
-                      (progn
-                        (goto-char here)
+                          (let ((pt (point)))
+                            (verilog-backward-syntactic-ws)
+                            (beginning-of-line)
+                            (while (and (not (looking-at regexp1))
+                                        (looking-at verilog-assignment-operation-re)
+                                        (not (bobp)))
+                              (setq pt (point))
+                              (verilog-backward-syntactic-ws)
+                              (beginning-of-line)) ; Ack, need to grok `define
+                            pt)))
+                 (end (save-excursion ; EOL of the last line of the assignment block
                         (end-of-line)
-                        (setq e (point))	;Might be on last line
-                        (verilog-forward-syntactic-ws)
-                        (beginning-of-line)
-                        (while (and
-                                (not (looking-at rexp1 ))
-                                (looking-at verilog-assignment-operation-re)
-                                (progn
-                                  (end-of-line)
-                                  (not (eq e (point)))))
-                          (setq e (point))
+                        (let ((pt (point))) ; Might be on last line
                           (verilog-forward-syntactic-ws)
                           (beginning-of-line)
-                          )
-                        e))
-                     (endpos (set-marker (make-marker) end))
-                     (ind)
-                     )
-                (goto-char start)
-                (verilog-do-indent (verilog-calculate-indent))
-                (if (and (not quiet)
-                         (> (- end start) 100))
-                    (message "Lining up expressions..(please stand by)"))
+                          (while (and
+                                  (not (looking-at regexp1))
+                                  (looking-at verilog-assignment-operation-re)
+                                  (progn
+                                    (end-of-line)
+                                    (not (eq pt (point)))))
+                            (setq pt (point))
+                            (verilog-forward-syntactic-ws)
+                            (beginning-of-line))
+                          pt)))
+                 (contains-2-char-operator (string-match "<=" (buffer-substring-no-properties start end)))
+                 (endmark (set-marker (make-marker) end)))
+            (goto-char start)
+            (verilog-do-indent (verilog-calculate-indent))
+            (when (and (not quiet)
+                       (> (- end start) 100))
+              (message "Lining up expressions.. (please stand by)"))
 
-                ;; Set indent to minimum throughout region
-                (while (< (point) (marker-position endpos))
-                  (beginning-of-line)
-                  (verilog-just-one-space verilog-assignment-operation-re)
-                  (beginning-of-line)
-                  (verilog-do-indent (verilog-calculate-indent))
-                  (end-of-line)
-                  (verilog-forward-syntactic-ws)
-                  )
+            ;; Set indent to minimum throughout region
+            ;; Rely on mark rather than on point as the indentation changes can
+            ;; make the older point reference obsolete
+            (while (< (point) (marker-position endmark))
+              (beginning-of-line)
+              (save-excursion
+                (verilog-just-one-space verilog-assignment-operation-re))
+              (verilog-do-indent (verilog-calculate-indent))
+              (end-of-line)
+              (verilog-forward-syntactic-ws))
 
-                ;; Now find biggest prefix
-                (setq ind (verilog-get-lineup-indent-2 verilog-assignment-operation-re start endpos))
-
-                ;; Now indent each line.
-                (goto-char start)
-                (while (progn (setq e (marker-position endpos))
-                              (setq r (- e (point)))
-                              (> r 0))
-                  (setq e (point))
-                  (if (not quiet) (message "%d" r))
-                  (cond
-                   ((looking-at verilog-assignment-operation-re)
-                    (goto-char (match-beginning 2))
-                    (if (not (or (verilog-in-parenthesis-p)  ; leave attributes and comparisons alone
-                                 (verilog-in-coverage-p)))
-                        (if (eq (char-after) ?=)
-                            (indent-to (1+ ind))	; line up the = of the <= with surrounding =
-                          (indent-to ind)
-                          ))
-                    )
-                   ((verilog-continued-line-1 start)
-                    (goto-char e)
-                    (indent-line-to ind))
-                   (t		; Must be comment or white space
-                    (goto-char e)
-                    (verilog-forward-ws&directives)
-                    (forward-line -1))
-                   )
-                  (forward-line 1))
-                (unless quiet (message ""))
-                ))))))
+            (let ((ind (verilog-get-lineup-indent-2 verilog-assignment-operation-re start (marker-position endmark))) ; Find the biggest prefix
+                  e)
+              ;; Now indent each line.
+              (goto-char start)
+              (while (progn
+                       (setq e (marker-position endmark))
+                       (> e (point)))
+                (unless quiet
+                  (message " verilog-pretty-expr: %d" (- e (point))))
+                (setq e (point))
+                (cond
+                 ((looking-at verilog-assignment-operation-re)
+                  (goto-char (match-beginning 2))
+                  (unless (or (verilog-in-parenthesis-p) ; Leave attributes and comparisons alone
+                              (verilog-in-coverage-p))
+                    (if (and contains-2-char-operator
+                             (eq (char-after) ?=))
+                        (indent-to (1+ ind)) ; Line up the = of the <= with surrounding =
+                      (indent-to ind))))
+                 ((verilog-continued-line-1 start)
+                  (goto-char e)
+                  (indent-line-to ind))
+                 (t                     ; Must be comment or white space
+                  (goto-char e)
+                  (verilog-forward-ws&directives)
+                  (forward-line -1)))
+                (forward-line 1))
+              (unless quiet
+                (message "")))))))))
 
 (defun verilog-just-one-space (myre)
   "Remove extra spaces around regular expression MYRE."
@@ -7182,30 +7173,30 @@ Region is defined by B and EDPOS."
 	;;(skip-chars-backward " \t")
 	(1+ (current-column))))))
 
-(defun verilog-get-lineup-indent-2 (myre b edpos)
-  "Return the indent level that will line up several lines within the region."
+(defun verilog-get-lineup-indent-2 (regexp beg end)
+  "Return the indent level that will line up several lines.
+The lineup string is searched using REGEXP within the region between points
+BEG and END."
   (save-excursion
-    (let ((ind 0) e)
-      (goto-char b)
+    (let ((ind 0))
+      (goto-char beg)
       ;; Get rightmost position
-      (while (progn (setq e (marker-position edpos))
-		    (< (point) e))
-	(if (and (verilog-re-search-forward myre e 'move)
-                 (not (verilog-in-attribute-p)))  ; skip attribute exprs
-	    (progn
-	      (goto-char (match-beginning 2))
-	      (verilog-backward-syntactic-ws)
-	      (if (> (current-column) ind)
-		  (setq ind (current-column)))
-	      (goto-char (match-end 0)))
-	  ))
-      (if (> ind 0)
-	  (1+ ind)
-	;; No lineup-string found
-	(goto-char b)
-	(end-of-line)
-	(skip-chars-backward " \t")
-	(1+ (current-column))))))
+      (while (< (point) end)
+	(when (and (verilog-re-search-forward regexp end 'move)
+                   (not (verilog-in-attribute-p))) ; skip attribute exprs
+	  (goto-char (match-beginning 2))
+	  (verilog-backward-syntactic-ws)
+	  (if (> (current-column) ind)
+	      (setq ind (current-column)))
+	  (goto-char (match-end 0))))
+      (setq ind (if (> ind 0)
+	            (1+ ind)
+	          ;; No lineup-string found
+	          (goto-char beg)
+	          (end-of-line)
+	          (skip-chars-backward " \t")
+	          (1+ (current-column))))
+      ind)))
 
 (defun verilog-comment-depth (type val)
   "A useful mode debugging aide.  TYPE and VAL are comments for insertion."


### PR DESCRIPTION
This PR fixes https://www.veripool.org/issues/1128-Verilog-mode--there-are-2-spaces-at-the-left-side-of-while-verilog-auto-lineup-all

Now the assignments in

    initial begin
       foo = 0;
       ba = 1;
       r = 2;
    end

line up as:

    initial begin
       foo = 0;
       ba  = 1;
       r   = 2;
    end

Not with double spaces before the equals as before:

    initial begin
       foo  = 0;
       ba   = 1;
       r    = 2;
    end

This commit does not change anything for the cases where all assign statements are of non-blocking type or a mix of blocking and non-blocking types.

The main test to test this change is: https://github.com/veripool/verilog-mode/compare/master...kaushalmodi:fix-extra-space-by-verilog-pretty-expr?expand=1#diff-3609412c41272f37bf27a0a04acd5f8d

I have updated the **full** test suite to reflect this. `make clean && make test` pass.

PS: My FSF Copyright Assignment is already on file.