### PR TITLE
Add rand keyword to verilog-declaration-prefix-re

### DIFF
--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -2730,6 +2730,8 @@ find the errors."
        "localparam" "parameter" "var"
        ;; type creation
        "typedef"
+       ;; randomness
+       "rand"
        ))))
 (defconst verilog-declaration-core-re
   (eval-when-compile


### PR DESCRIPTION
rand keyword also can be part of property declaration inside class definitions.