### PR TITLE
Handle line directives in port list while "parsing" AUTOINSTed modules

### DIFF
--- a/tests/autoinst_line.v
+++ b/tests/autoinst_line.v
@@ -1,0 +1,18 @@
+module foo();
+   bar i0 (
+	   /*AUTOINST*/
+	   );
+endmodule // foo
+
+module bar(
+`line 2 "bar.v" 0
+	   input  logic a,
+`line 3 "bar.v" 0
+	   input  logic b,
+`line 4 "bar.v" 0
+	   output logic c,
+`line 5 "bar.v" 0
+	   input  logic clk
+`line 6 "bar.v" 0
+	   );
+endmodule // bar

--- a/tests_ok/autoinst_line.v
+++ b/tests_ok/autoinst_line.v
@@ -1,0 +1,23 @@
+module foo();
+   bar i0 (
+           /*AUTOINST*/
+           // Outputs
+           .c                           (c),
+           // Inputs
+           .a                           (a),
+           .b                           (b),
+           .clk                         (clk));
+endmodule // foo
+
+module bar(
+`line 2 "bar.v" 0
+           input logic  a,
+`line 3 "bar.v" 0
+           input logic  b,
+`line 4 "bar.v" 0
+           output logic c,
+`line 5 "bar.v" 0
+           input logic  clk
+`line 6 "bar.v" 0
+           );
+endmodule // bar

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -8629,6 +8629,9 @@ Return an array of [outputs inouts inputs wire reg assign const]."
 		;; Ifdef?  Ignore name of define
 		((member keywd '("`ifdef" "`ifndef" "`elsif"))
 		 (setq rvalue t))
+		;; Line directive? Skip over the rest of the line
+		((equal keywd "`line")
+		 (forward-line))
 		;; Type?
 		((unless ptype
 		   (verilog-typedef-name-p keywd))


### PR DESCRIPTION
This PR attempts to fix and issue with `line` directives that may appear in the port list of an `AUTOINST`ed sub-module. Without this PR, the following top module:
```
module foo();

   bar i0 (
             /*AUTOINST*/
           );
   
endmodule // foo
```
instantiating this sub-module:
```
module bar(
`line 2 "bar.v" 0
           input  logic a
`line 3 "bar.v" 0
           );

endmodule // bar
```
results in:
```
module foo();

   bar i0 (
             /*AUTOINST*/
           // Inputs
           .a                           (a),
           .3                           (3),
           .0                           (0));
   
endmodule // foo
```