### PR TITLE
Skip over base-64-encoded protected data while reading declarations

### DIFF
--- a/tests/autoinst_protected.v
+++ b/tests/autoinst_protected.v
@@ -1,0 +1,12 @@
+module foo();
+   bar i0 (
+           /*AUTOINST*/
+           );
+endmodule // foo
+
+module bar(input logic a);
+`pragma protect begin_protected
+`pragma protect data_block
+   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA[
+`pragma protect end_protected
+endmodule // bar

--- a/tests_ok/autoinst_protected.v
+++ b/tests_ok/autoinst_protected.v
@@ -1,0 +1,13 @@
+module foo();
+   bar i0 (
+           /*AUTOINST*/
+           // Inputs
+           .a                           (a));
+endmodule // foo
+
+module bar(input logic a);
+`pragma protect begin_protected
+`pragma protect data_block
+   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA[
+`pragma protect end_protected
+                                                                               endmodule // bar

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -8489,6 +8489,10 @@ Return an array of [outputs inouts inputs wire reg assign const]."
             (setq enum (match-string-no-properties 2)))
 	  (or (search-forward "*/")
 	      (error "%s: Unmatched /* */, at char %d" (verilog-point-text) (point))))
+	 ;; Skip over protected sections with Base64-encoded data
+	 ((looking-at "^\\s *`pragma\\s +protect\\s +begin_protected")
+	  (or (re-search-forward "^\\s *`pragma\\s +protect\\s +end_protected" nil t)
+	      (forward-line)))
 	 ((looking-at "(\\*")
 	  ;; To advance past either "(*)" or "(* ... *)" don't forward past first *
 	  (forward-char 1)


### PR DESCRIPTION
This PR attempts to fix `Scan error: "Unbalanced parentheses", ...` (and other) scanning errors that occur while `verilog-mode` reads module declarations for auto-instantiation of modules that contain Base64-encoded lines for protected Verilog.

~~I am not able to provide a test case at this time as we encountered this issue in a licensed 3rd-party IP block.~~