### PR TITLE
Corrects a syntax error, to fix issue https://github.com/veripool/ver…

### DIFF
--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -3298,7 +3298,7 @@ See also `verilog-font-lock-extra-types'.")
 		 (list
                  "\\<\\(\\(macro\\|connect\\)?module\\|primitive\\|class\\|program\\|interface\\|package\\|task\\)\\>\\s-*\\(\\sw+\\)"
 		  '(1 font-lock-keyword-face)
-		  '(3 font-lock-function-name-face 'prepend))
+		  '(3 font-lock-function-name-face prepend))
 		 ;; Fontify function definitions
 		 (list
 		  (concat "\\<function\\>\\s-+\\(integer\\|real\\(time\\)?\\|time\\)\\s-+\\(\\sw+\\)" )


### PR DESCRIPTION
The specific `subex-highlighter` was being ignored due to the extra `'` before `prepend`. The reason module name was still being highlighted when `(` was in the same line is because it matched this on line 3339:
```
;; Fontify instantiation names
'("\\([A-Za-z][A-Za-z0-9_]*\\)\\s-*(" 1 font-lock-function-name-face)
```