### PR TITLE
Allows parameter declaration statements to be treated as like any other declaration

### DIFF
--- a/tests/autosense_inc_param.v
+++ b/tests/autosense_inc_param.v
@@ -1,6 +1,3 @@
-
 parameter [2:0] PARAM_TWO = 2,
 	     PARAM_THREE = 3;
 parameter PARAM_FOUR = 4;
-
-

--- a/tests/indent_comments.v
+++ b/tests/indent_comments.v
@@ -1,7 +1,5 @@
 module dummy (
 	      input wire xx,
 	      output wire yy, // comment with paren ) adsfasdf
-	      ouput wire zz); // oops - matched paren in comment!!
+	      output wire zz); // oops - matched paren in comment!!
 endmodule // dummy
-
-

--- a/tests_ok/ExampInoutParam.v
+++ b/tests_ok/ExampInoutParam.v
@@ -5,7 +5,7 @@ endmodule
 module ExampInoutParam ();
    /*AUTOINOUTPARAM("ExampMain")*/
    // Beginning of automatic parameters (from specific module)
-   parameter       PARAM;
+   parameter PARAM;
    // End of automatics
 endmodule
 

--- a/tests_ok/ExampParamVal1.v
+++ b/tests_ok/ExampParamVal1.v
@@ -1,8 +1,8 @@
 module InstModule (o,i);
-   parameter WIDTH;
+   parameter         WIDTH;
    input [WIDTH-1:0] i;
-   parameter type OUT_t;
-   output OUT_t o;
+   parameter         type OUT_t;
+   output            OUT_t o;
 endmodule
 
 module vm_example1;

--- a/tests_ok/ExampParamVal2.v
+++ b/tests_ok/ExampParamVal2.v
@@ -1,8 +1,8 @@
 module InstModule (o,i);
-   parameter WIDTH;
+   parameter         WIDTH;
    input [WIDTH-1:0] i;
-   parameter type OUT_t;
-   output OUT_t o;
+   parameter         type OUT_t;
+   output            OUT_t o;
 endmodule
 
 module vm_example1;

--- a/tests_ok/ExampStub.v
+++ b/tests_ok/ExampStub.v
@@ -13,28 +13,28 @@ module ExampStub (/*AUTOARG*/
                   );
    /*AUTOINOUTPARAM("ExampMain")*/
    // Beginning of automatic parameters (from specific module)
-   parameter       P;
+   parameter P;
    // End of automatics
    /*AUTOINOUTMODULE("ExampMain")*/
    // Beginning of automatic in/out/inouts (from specific module)
-   output o;
-   inout  io;
-   input  i;
+   output    o;
+   inout     io;
+   input     i;
    // End of automatics
    
    /*AUTOTIEOFF*/
    // Beginning of automatic tieoffs (for this module's unterminated outputs)
-   wire   o = 1'h0;
+   wire      o = 1'h0;
    // End of automatics
    
    // verilator lint_off UNUSED
-   wire   _unused_ok = &{1'b0,
-                         /*AUTOUNUSED*/
-                         // Beginning of automatic unused inputs
-                         i,
-                         io,
-                         // End of automatics
-                         1'b0};
+   wire      _unused_ok = &{1'b0,
+                            /*AUTOUNUSED*/
+                            // Beginning of automatic unused inputs
+                            i,
+                            io,
+                            // End of automatics
+                            1'b0};
    // verilator lint_on  UNUSED
 endmodule
 

--- a/tests_ok/autoascii_myers.v
+++ b/tests_ok/autoascii_myers.v
@@ -1,31 +1,31 @@
 module testit;
-   reg       clk;
-   reg       a_i;
-   reg       b_i;
+   reg             clk;
+   reg             a_i;
+   reg             b_i;
    
-   reg       a_o;
-   reg       b_o;
-   reg       rst_n;
+   reg             a_o;
+   reg             b_o;
+   reg             rst_n;
    
-   reg [7:0] shreg;
+   reg [7:0]       shreg;
    
    
    //== State enumeration
    parameter [2:0] // synopsys enum state_info
-     SM_IDLE  = 3'b000,
-     SM_SEND  = 3'b001,
-     SM_WAIT1 = 3'b010;
+                   SM_IDLE = 3'b000,
+                   SM_SEND = 3'b001,
+                   SM_WAIT1 = 3'b010;
    //== State variables
-   reg [2:0]  /* synopsys enum state_info */
-              state_r; /* synopsys state_vector state_r */
-   reg [2:0]  /* synopsys enum state_info */
-              state_e1;
+   reg [2:0]       /* synopsys enum state_info */
+                   state_r; /* synopsys state_vector state_r */
+   reg [2:0]       /* synopsys enum state_info */
+                   state_e1;
    
    //== ASCII state decoding
    
    /*AUTOASCIIENUM("state_r", "_stateascii_r", "sm_")*/
    // Beginning of automatic ASCII enum decoding
-   reg [39:0] _stateascii_r;            // Decode of state_r
+   reg [39:0]      _stateascii_r;               // Decode of state_r
    always @(state_r) begin
       case ({state_r})
         SM_IDLE:  _stateascii_r = "idle ";

--- a/tests_ok/autoascii_peltan.v
+++ b/tests_ok/autoascii_peltan.v
@@ -8,16 +8,16 @@ module autoascii_peltan
    
    // Duplicate of what's in _inc
    localparam [3:0] /* synopsys enum xstate */
-     state0 = 4'h0;
+                    state0 = 4'h0;
    
-   wire [3:0] /* synopsys enum xstate */
-              xstate;
+   wire [3:0]       /* synopsys enum xstate */
+                    xstate;
    
    /* synopsys translate off */
    
    /*AUTOASCIIENUM("xstate", "v_xstate")*/
    // Beginning of automatic ASCII enum decoding
-   reg [47:0] v_xstate;         // Decode of xstate
+   reg [47:0]       v_xstate;           // Decode of xstate
    always @(xstate) begin
       case ({xstate})
         state0:   v_xstate = "state0";

--- a/tests_ok/autoascii_peltan_inc.v
+++ b/tests_ok/autoascii_peltan_inc.v
@@ -1,3 +1,3 @@
 localparam [3:0] /* synopsys enum xstate */
-  state0 = 4'h0,
-  state1 = 4'h1;
+                 state0 = 4'h0,
+                 state1 = 4'h1;

--- a/tests_ok/autoasciienum_auto.v
+++ b/tests_ok/autoasciienum_auto.v
@@ -2,21 +2,21 @@
 
 module autoasciienum_auto();
    
-   reg [2:0] /* auto enum sm_psm */ sm_psm;
-   reg [2:0] /* auto enum sm_ps2 */ sm_ps2;
+   reg [2:0]        /* auto enum sm_psm */ sm_psm;
+   reg [2:0]        /* auto enum sm_ps2 */ sm_ps2;
    
    localparam [2:0] // auto enum sm_psm
-     PSM_IDL = 0,
-     PSM_RST = 6,
-     PSM_ZOT = 7;
+                    PSM_IDL = 0,
+                    PSM_RST = 6,
+                    PSM_ZOT = 7;
    
    localparam [2:0] // auto enum sm_ps2
-     PS2_IDL = 0,
-     PS2_FOO = 1;
+                    PS2_IDL = 0,
+                    PS2_FOO = 1;
    
    /*AUTOASCIIENUM("sm_psm", "_sm_psm__ascii", "_")*/
    // Beginning of automatic ASCII enum decoding
-   reg [47:0] _sm_psm__ascii;           // Decode of sm_psm
+   reg [47:0]       _sm_psm__ascii;             // Decode of sm_psm
    always @(sm_psm) begin
       case ({sm_psm})
         PSM_IDL:  _sm_psm__ascii = "psmidl";

--- a/tests_ok/autoasciienum_ex.v
+++ b/tests_ok/autoasciienum_ex.v
@@ -3,24 +3,24 @@ module sm (/*AUTOARG*/
            state_e1, state_r
            );
    
-   output [2:0] state_e1;
-   output [2:0] state_r;
+   output [2:0]    state_e1;
+   output [2:0]    state_r;
    
    //== State enumeration
    parameter [2:0] // synopsys enum state_info
-     SM_IDLE = 3'b000,
-     SM_ACT  = 3'b010;
+                   SM_IDLE = 3'b000,
+                   SM_ACT = 3'b010;
    //== State variables
-   reg [2:0]  /* synopsys enum state_info */
-              state_r; /* synopsys state_vector state_r */
-   reg [2:0]  /* synopsys enum state_info */
-              state_e1;
+   reg [2:0]       /* synopsys enum state_info */
+                   state_r; /* synopsys state_vector state_r */
+   reg [2:0]       /* synopsys enum state_info */
+                   state_e1;
    
    //== ASCII state decoding
    
    /*AUTOASCIIENUM("state_r", "_stateascii_r", "sm_")*/
    // Beginning of automatic ASCII enum decoding
-   reg [31:0] _stateascii_r;            // Decode of state_r
+   reg [31:0]      _stateascii_r;               // Decode of state_r
    always @(state_r) begin
       case ({state_r})
         SM_IDLE:  _stateascii_r = "idle";

--- a/tests_ok/autoasciienum_onehot.v
+++ b/tests_ok/autoasciienum_onehot.v
@@ -7,14 +7,14 @@ module autoasciienum_onehot (
                              );
    
    localparam // synopsys enum state_info
-     IDLE = 0,
-     S1   = 1,
-     S2   = 2,
-     S3   = 3,
-     DONE = 4;
+              IDLE = 0,
+              S1 = 1,
+              S2 = 2,
+              S3 = 3,
+              DONE = 4;
    
-   reg [4:0] // synopsys enum state_info
-             cur_state, nxt_state;
+   reg [4:0]  // synopsys enum state_info
+              cur_state, nxt_state;
    
    always @ (*) begin
       nxt_state = 5'h0;

--- a/tests_ok/autoasciienum_param.v
+++ b/tests_ok/autoasciienum_param.v
@@ -6,11 +6,11 @@ module just_for_proper_indentation ();
    //Verilint 175 off //WARNING: Unused parameter
    
    parameter // synopsys enum En_C14ChipNum
-     EP_C14ChipNum_OASP = 4'h0,
-     EP_C14ChipNum_DLE  = 4'h2,
-     EP_C14ChipNum_TTE  = 4'h3,
-     EP_C14ChipNum_SMM  = 4'h4,
-     EP_C14ChipNum_SMM2 = 4'h5,
-     EP_C14ChipNum_SRP  = 4'h6,
-     EP_C14ChipNum_SPP  = 4'h7,
-     EP_C14ChipNum_RNP  = 4'h8;
+             EP_C14ChipNum_OASP = 4'h0,
+             EP_C14ChipNum_DLE  = 4'h2,
+             EP_C14ChipNum_TTE  = 4'h3,
+             EP_C14ChipNum_SMM  = 4'h4,
+             EP_C14ChipNum_SMM2 = 4'h5,
+             EP_C14ChipNum_SRP  = 4'h6,
+             EP_C14ChipNum_SPP  = 4'h7,
+             EP_C14ChipNum_RNP  = 4'h8;

--- a/tests_ok/autoasciienum_reed.v
+++ b/tests_ok/autoasciienum_reed.v
@@ -1,16 +1,16 @@
 
 module sm ();
    
-   localparam STATES = 7;
+   localparam       STATES = 7;
    
-   localparam /* synopsys enum states */
-     IDLE        = 0, // '001
-     READ        = 1, // '002
-     THINK       = 2, // '004
-     SEND        = 3, // '008
-     WAIT        = 4, // '040
-     GET_ACK     = 5, // '080
-     WAIT_REGBUS = 6; // '100
+   localparam       /* synopsys enum states */
+                    IDLE = 0, // '001
+                    READ = 1, // '002
+                    THINK = 2, // '004
+                    SEND = 3, // '008
+                    WAIT = 4, // '040
+                    GET_ACK = 5, // '080
+                    WAIT_REGBUS = 6; // '100
    
    reg [STATES-1:0] /*synopsys enum states*/
                     state_i, state_r; /* synopsys state_vector state_r */

--- a/tests_ok/autoasciienum_sm.v
+++ b/tests_ok/autoasciienum_sm.v
@@ -7,36 +7,36 @@ module sm (/*AUTOARG*/
    
    //==================== Constant declarations ==============
    
-   parameter [2:0]      // synopsys enum state_info
-     IDLE                                                      = 3'b000,
-     SEND                                                      = 3'b001,
-     WAIT1                                                     = 3'b010,
-     UPDATE1                                                   = 3'b011,
-     WAIT2                                                     = 3'b100;
+   parameter [2:0] // synopsys enum state_info
+                   IDLE = 3'b000,
+                   SEND = 3'b001,
+                   WAIT1 = 3'b010,
+                   UPDATE1 = 3'b011,
+                   WAIT2 = 3'b100;
    
-   parameter [2:0]      /* synopsys enum state_info */ UPDATE2 = 3'b101;
+   parameter [2:0] /* synopsys enum state_info */ UPDATE2 = 3'b101;
    
-   parameter [2:0]      NOT_A_STATE_ELEMENT = 3'b101;
+   parameter [2:0] NOT_A_STATE_ELEMENT = 3'b101;
    
-   parameter [2:0]      /* synopsys enum other */
-     A_OTHER_STATE_ELEMENT = 3'b101;
+   parameter [2:0] /* synopsys enum other */
+                   A_OTHER_STATE_ELEMENT = 3'b101;
    
    //==================== Input Signals ======================
    
-   input        clk; // System clock signal
-   input        rst_;
+   input           clk; // System clock signal
+   input           rst_;
    
    //==================== Output Signals =====================
    
    // s_ynopsys requires the enum comment between the keyword and the symbol While this seems silly,
    // verilog requires this also to avoid misleading people that also use their tools.
    
-   output [2:0] state_r; // SM State information (to GPF)
+   output [2:0]    state_r; // SM State information (to GPF)
    
    //==================== Intermediate Variables =============
    
-   reg [2:0]    /* synopsys enum state_info */ state_r; /* synopsys state_vector state_r */
-   reg [2:0]    /* synopsys enum state_info */ state_e1;                // next state of state-machine
+   reg [2:0]       /* synopsys enum state_info */ state_r; /* synopsys state_vector state_r */
+   reg [2:0]       /* synopsys enum state_info */ state_e1;             // next state of state-machine
    
    //==================== Code Begin =========================
    

--- a/tests_ok/autoinoutparam.v
+++ b/tests_ok/autoinoutparam.v
@@ -2,12 +2,12 @@ module autoinoutparam (/*AUTOARG*/);
    
    /*AUTOINOUTPARAM("inst","param1")*/
    // Beginning of automatic parameters (from specific module)
-   parameter            param1;
+   parameter param1;
    // End of automatics
    
    /*AUTOINOUTPARAM("inst")*/
    // Beginning of automatic parameters (from specific module)
-   parameter            param2;
+   parameter param2;
    // End of automatics
    
 endmodule

--- a/tests_ok/autoinst_clog2_bug522.v
+++ b/tests_ok/autoinst_clog2_bug522.v
@@ -19,8 +19,8 @@ module submod (/*AUTOARG*/
                // Inputs
                vec
                );
-   parameter VEC_W = 32;
-   parameter IDX_W = $clog2(VEC_W);
+   parameter          VEC_W = 32;
+   parameter          IDX_W = $clog2(VEC_W);
    input [VEC_W-1:0]  vec;
    output [IDX_W-1:0] idx;
 endmodule

--- a/tests_ok/autoinst_lopaz.v
+++ b/tests_ok/autoinst_lopaz.v
@@ -1,8 +1,8 @@
 module io1_sub(
                /*AUTOARG*/);
    
-   wire [42:0] bscan_data;         // boundary scan stitch
-   parameter    bscan_count = 0;
+   wire [42:0] bscan_data; // boundary scan stitch
+   parameter   bscan_count = 0;
    
    assign       bscan_data[0] = bscan_in;
    

--- a/tests_ok/autoinst_lopaz_srpad.v
+++ b/tests_ok/autoinst_lopaz_srpad.v
@@ -6,7 +6,7 @@ module autoinst_lopaz_srpad (/*AUTOARG*/
                              // Inputs
                              clk, pin_out, pin_outen
                              );
-   parameter w = 1;
+   parameter        w = 1;
    input            clk;
    
    inout [w-1:0]    pin;

--- a/tests_ok/autoinst_param_2d.v
+++ b/tests_ok/autoinst_param_2d.v
@@ -1,10 +1,10 @@
 // bug981
 
 module a(
-         parameter AUM=80;
-         parameter BUM=70;
-         parameter VUM=1;
-         parameter V2=2;
+         parameter                AUM=80;
+         parameter                BUM=70;
+         parameter                VUM=1;
+         parameter                V2=2;
          input                    my_data_z;
          input                    my_data_v[VUM];
          input                    my_data_vv[VUM][V2];

--- a/tests_ok/autoinst_param_type.v
+++ b/tests_ok/autoinst_param_type.v
@@ -53,10 +53,10 @@ endmodule
 // Example in docs
 
 module InstModule (o,i);
-   parameter WIDTH;
+   parameter         WIDTH;
    input [WIDTH-1:0] i;
-   parameter type OUT_t;
-   output OUT_t o;
+   parameter         type OUT_t;
+   output            OUT_t o;
 endmodule
 
 module ExampInst;

--- a/tests_ok/autoinst_param_value.v
+++ b/tests_ok/autoinst_param_value.v
@@ -1,5 +1,5 @@
 module InstMod ( ins, outs );
-   parameter WIDTH;
+   parameter          WIDTH;
    output [WIDTH-1:0] ins;
 endmodule
 

--- a/tests_ok/autoinst_paramover.v
+++ b/tests_ok/autoinst_paramover.v
@@ -7,8 +7,8 @@ module autoinst_paramover (/*AUTOARG*/
    // Inputs/Outputs
    //======================================================================
    
-   parameter bitsa = 20;
-   parameter bitsb = 20;
+   parameter    bitsa = 20;
+   parameter    bitsb = 20;
    
    inout [20:0] a; // SDRAM Channel 0 Row Address Strobe
    inout [20:0] b;         // SDRAM Channel 0 Row Address Strobe

--- a/tests_ok/autoinst_paramover_sub.v
+++ b/tests_ok/autoinst_paramover_sub.v
@@ -7,8 +7,8 @@ module autoinst_paramover_sub (/*AUTOARG*/
    // Inputs/Outputs
    //======================================================================
    
-   parameter bitsa;
-   parameter bitsb;
+   parameter       bitsa;
+   parameter       bitsb;
    
    inout [bitsa:0] a; // SDRAM Channel 0 Row Address Strobe
    inout [bitsb:0] b;         // SDRAM Channel 0 Row Address Strobe

--- a/tests_ok/autoinst_regexp_inst.v
+++ b/tests_ok/autoinst_regexp_inst.v
@@ -1,6 +1,6 @@
 module sub;
    parameter AA, AB, AC;
-   output ia, ib, ic;
+   output    ia, ib, ic;
 endmodule
 
 module autoinst_regexp_inst;

--- a/tests_ok/autoinst_sv_kulkarni.v
+++ b/tests_ok/autoinst_sv_kulkarni.v
@@ -33,8 +33,8 @@ endmodule
 // Top-level module or Testbench
 // -----------------------------------------------------------------------------
 module top;
-   parameter M=4;
-   parameter N=2;
+   parameter            M=4;
+   parameter            N=2;
    
    wire [N-1:0]         a_o1;
    logic [N-1:0][M-1:0] a_i1;

--- a/tests_ok/autoinst_unsigned_bug302.v
+++ b/tests_ok/autoinst_unsigned_bug302.v
@@ -14,7 +14,7 @@ endmodule
 
 module Sub
   #(
-    parameter No1 = 6,
+    parameter              No1 = 6,
     parameter int unsigned No2 // Parameter no. 2
                            = pa_Abc::No2,
     parameter bit          No3 [No1:0][No2-1:0] // Parameter no. 3

--- a/tests_ok/autoinst_vkadamby.v
+++ b/tests_ok/autoinst_vkadamby.v
@@ -11,7 +11,7 @@ module child1 (/*AUTOARG*/
                x
                );
    
-   input x;
+   input     x;
    parameter lengthM2;
    
 endmodule

--- a/tests_ok/autoinstparam_belkind_leaf.v
+++ b/tests_ok/autoinstparam_belkind_leaf.v
@@ -3,7 +3,7 @@ module autoinstparam_belkind_leaf (/*AUTOARG*/
                                    a
                                    ) ;
    
-   parameter P =3D 4;
+   parameter     P =3D 4;
    input [P-1:0] a;
    
 endmodule // leaf

--- a/tests_ok/autoinstparam_bug287.v
+++ b/tests_ok/autoinstparam_bug287.v
@@ -1,5 +1,5 @@
 module Ptest #(
-               parameter I_CONTROL     = 8'h 00, R_CONTROL     = 8'h00)
+               parameter I_CONTROL = 8'h 00, R_CONTROL = 8'h00)
    (
     input scanTest,
     input scanArst);

--- a/tests_ok/autoinstparam_first_sub.v
+++ b/tests_ok/autoinstparam_first_sub.v
@@ -7,9 +7,9 @@ module autoinstparam_first_sub (/*AUTOARG*/
    // Inputs/Outputs
    //======================================================================
    
-   localparam IGNORED;
-   parameter BITSA;
-   parameter type BITSB_t = bit;   // See bug340
+   localparam      IGNORED;
+   parameter       BITSA;
+   parameter       type BITSB_t = bit; // See bug340
    
    inout [BITSA:0] a;
    inout           BITSB_t b;

--- a/tests_ok/autoinstparam_int.v
+++ b/tests_ok/autoinstparam_int.v
@@ -1,7 +1,7 @@
 module xyz
   #(parameter int FOO=1, BAR=2,
     parameter logic [5:0] BLUP=3, ZOT=4,
-    parameter LDWRDS=5)
+    parameter             LDWRDS=5)
    ( input x1, x2,
      input int         i1, i2,
      input logic [5:0] i3, i4,

--- a/tests_ok/autoinstparam_local.v
+++ b/tests_ok/autoinstparam_local.v
@@ -1,8 +1,8 @@
 //bug889
 
 module leaf #(
-              parameter   DATA_WIDTH = 256,
-              localparam  STRB_WIDTH_SHOULD_BE_HIDDEN = DATA_WIDTH/8 )
+              parameter  DATA_WIDTH = 256,
+              localparam STRB_WIDTH_SHOULD_BE_HIDDEN = DATA_WIDTH/8 )
    ();
 endmodule
 

--- a/tests_ok/autoreset_widths.v
+++ b/tests_ok/autoreset_widths.v
@@ -30,8 +30,8 @@ module CmpEng (/*AUTOARG*/
    
 `define M 2
 `define L 1
-   parameter MS = 2;
-   parameter LS = 1;
+   parameter   MS = 2;
+   parameter   LS = 1;
    
    reg [MS:LS] m_param_r;
    reg [`M:`L] m_def2_r;

--- a/tests_ok/autoreset_widths_unbased.v
+++ b/tests_ok/autoreset_widths_unbased.v
@@ -30,8 +30,8 @@ module CmpEng (/*AUTOARG*/
    
 `define M 2
 `define L 1
-   parameter MS = 2;
-   parameter LS = 1;
+   parameter   MS = 2;
+   parameter   LS = 1;
    
    reg [MS:LS] m_param_r;
    reg [`M:`L] m_def2_r;

--- a/tests_ok/autosense_aas_ifdef.v
+++ b/tests_ok/autosense_aas_ifdef.v
@@ -1,14 +1,14 @@
 module dummy;
    
    parameter [TSTBITS-1:0] // synopsys enum tstate_info
-     TIDLE = 3'b000,
-     TCN1  = 3'b001,
-     TCN2  = TCN1+1, // must be numbered consecutively
-     TCN3  = TCN2+1,
-     TCN4  = TCN3+1,
-     TCN5  = TCN4+1,
-     IOCLR = TCN5+1,
-     TUNU1 = 3'b111;
+                           TIDLE = 3'b000,
+                           TCN1  = 3'b001,
+                           TCN2  = TCN1+1, // must be numbered consecutively
+                           TCN3  = TCN2+1,
+                           TCN4  = TCN3+1,
+                           TCN5  = TCN4+1,
+                           IOCLR = TCN5+1,
+                           TUNU1 = 3'b111;
    
    // state and output logic
    always @ (`ifdef SIMFSM

--- a/tests_ok/autosense_dittrich_inc.v
+++ b/tests_ok/autosense_dittrich_inc.v
@@ -1,7 +1,7 @@
 parameter sel_a = {1'b 0, 1'b 0}; // 2'd 0 works fine
 parameter sel_b = {1'b 0, 1'b 1}; // 2'd 1 works fine
 parameter sel_c = 2'd 2,
-  sel_d = 2'd 3;
+          sel_d = 2'd 3;
 
 //parameter sel_a = {1'b 0, 1'b 0}, // 2'd 0 works fine
 //        sel_b = {1'b 0, 1'b 1}, // 2'd 1 works fine

--- a/tests_ok/autosense_inc_param.v
+++ b/tests_ok/autosense_inc_param.v
@@ -1,6 +1,3 @@
-
 parameter [2:0] PARAM_TWO = 2,
-  PARAM_THREE = 3;
+                PARAM_THREE = 3;
 parameter PARAM_FOUR = 4;
-
-

--- a/tests_ok/autosense_smith.v
+++ b/tests_ok/autosense_smith.v
@@ -1,30 +1,30 @@
 module x;
    
-   reg [31:0] mb_reg_output;
+   reg [31:0]                                 mb_reg_output;
    
    // 16 registers max, register 15 is always the version number, so 15 are useable
    // NOTE: number_interface_regs must be the maximum (or 16 in this case) to get the version register
-   parameter               NUMBER_INTERFACE_REGS = 16;
-   parameter               MB_REG_START = 3; // start at 4th register location 'h0010
-   parameter               CMD_REG_0_ADDR = MB_REG_START;
-   parameter               CMD_REG_1_ADDR = MB_REG_START+1;
-   parameter               CMD_REG_2_ADDR = MB_REG_START+2;
-   parameter               CMD_REG_3_ADDR = MB_REG_START+3;
-   parameter               CMD_REG_4_ADDR = MB_REG_START+4;
-   parameter               CMD_REG_5_ADDR = MB_REG_START+5;
-   parameter               CMD_REG_6_ADDR = MB_REG_START+6;
-   parameter               CMD_REG_7_ADDR = MB_REG_START+7;
-   parameter               CMD_REG_8_ADDR = MB_REG_START+8;
-   parameter               CMD_REG_9_ADDR = MB_REG_START+9;
-   parameter               CMD_REG_10_ADDR = MB_REG_START+10;
+   parameter                                  NUMBER_INTERFACE_REGS = 16;
+   parameter                                  MB_REG_START = 3; // start at 4th register location 'h0010
+   parameter                                  CMD_REG_0_ADDR = MB_REG_START;
+   parameter                                  CMD_REG_1_ADDR = MB_REG_START+1;
+   parameter                                  CMD_REG_2_ADDR = MB_REG_START+2;
+   parameter                                  CMD_REG_3_ADDR = MB_REG_START+3;
+   parameter                                  CMD_REG_4_ADDR = MB_REG_START+4;
+   parameter                                  CMD_REG_5_ADDR = MB_REG_START+5;
+   parameter                                  CMD_REG_6_ADDR = MB_REG_START+6;
+   parameter                                  CMD_REG_7_ADDR = MB_REG_START+7;
+   parameter                                  CMD_REG_8_ADDR = MB_REG_START+8;
+   parameter                                  CMD_REG_9_ADDR = MB_REG_START+9;
+   parameter                                  CMD_REG_10_ADDR = MB_REG_START+10;
    // mode regs
-   parameter               MODE_REG_0_ADDR = CMD_REG_8_ADDR;
+   parameter                                  MODE_REG_0_ADDR = CMD_REG_8_ADDR;
    
    // Absolute register 14 is Error counter
-   parameter               CMD_REG_14_ADDR = 14;
-   parameter               CRC_ERROR_REG_ADDR = CMD_REG_14_ADDR;
+   parameter                                  CMD_REG_14_ADDR = 14;
+   parameter                                  CRC_ERROR_REG_ADDR = CMD_REG_14_ADDR;
    // ------------ VERSION register is 15
-   parameter               VERSION_REG_ADDR = 15;
+   parameter                                  VERSION_REG_ADDR = 15;
    
    reg [NUMBER_INTERFACE_REGS-1:MB_REG_START] mb_reg_wr;
    reg [NUMBER_INTERFACE_REGS-1:MB_REG_START] mb_reg_rd;

--- a/tests_ok/autotieoff_inoutmod.v
+++ b/tests_ok/autotieoff_inoutmod.v
@@ -15,8 +15,8 @@ module my_module_stub
   #(
     /*AUTOINOUTPARAM("my_module")*/
     // Beginning of automatic parameters (from specific module)
-    parameter           p,
-    parameter           r
+    parameter p,
+    parameter r
     // End of automatics
     )
    (

--- a/tests_ok/autowire_paramvec_bug302.v
+++ b/tests_ok/autowire_paramvec_bug302.v
@@ -31,7 +31,7 @@ endmodule
 
 module Abc
   #(
-    parameter No1 = 6,
+    parameter              No1 = 6,
     parameter int unsigned No2 // Parameter no. 2
                            = pa_Abc::No2,
     parameter bit          No3 [No1:0][No2-1:0] // Parameter no. 3

--- a/tests_ok/autowire_pkg_bug195.v
+++ b/tests_ok/autowire_pkg_bug195.v
@@ -4,9 +4,9 @@ package testcase_pkg;
    
    typedef int unsigned uint;
    
-   localparam uint SIZE = 8;
+   localparam           uint SIZE = 8;
    
-   typedef enum {ENUM1, ENUM2} enum_t;
+   typedef enum         {ENUM1, ENUM2} enum_t;
    
 endpackage
    

--- a/tests_ok/autowire_real.v
+++ b/tests_ok/autowire_real.v
@@ -1,7 +1,7 @@
 module sc_top (
-               input  var real Tx_vcm,
-               input  var real i_DAC_in,
-               input  i_Tx_SC_en,
+               input var  real Tx_vcm,
+               input var  real i_DAC_in,
+               input      i_Tx_SC_en,
                output var real Tx_vsc
                );
    
@@ -9,7 +9,7 @@ endmodule
 
 
 module cm_top (
-               input  i_Tx_CM_en,
+               input      i_Tx_CM_en,
                output var real Tx_vcm
                );
    

--- a/tests_ok/autowire_red_bracket.v
+++ b/tests_ok/autowire_red_bracket.v
@@ -1,7 +1,7 @@
 
 module top
   #(
-    parameter  NOF_TEST        = 6,
+    parameter         NOF_TEST = 6,
     parameter integer TEST [NOF_TEST] = '{10,20,30,40,50,60}
     )
    

--- a/tests_ok/autowire_shifts_bug1346.v
+++ b/tests_ok/autowire_shifts_bug1346.v
@@ -6,9 +6,9 @@ module design(/*AUTOARG*/
               // Inputs
               i0, i1
               );
-   parameter w1 = 2;
-   parameter w2 = 4;
-   parameter w3 = 256;
+   parameter                                             w1 = 2;
+   parameter                                             w2 = 4;
+   parameter                                             w3 = 256;
    input [w1:0]                                          i0;
    input [w2:0]                                          i1;
    

--- a/tests_ok/batch_li_parent.v
+++ b/tests_ok/batch_li_parent.v
@@ -3,8 +3,8 @@ module batch_li_parent (/*AUTOARG*/
                         clk, rst
                         );
    
-   input rst;
-   input clk;
+   input     rst;
+   input     clk;
    
    parameter WIDTH_0 = 8;
    parameter WIDTH_1 = 16;

--- a/tests_ok/indent_comments.v
+++ b/tests_ok/indent_comments.v
@@ -1,7 +1,5 @@
 module dummy (
               input wire  xx,
               output wire yy, // comment with paren ) adsfasdf
-              ouput wire zz); // oops - matched paren in comment!!
+              output wire zz); // oops - matched paren in comment!!
 endmodule // dummy
-
-

--- a/tests_ok/indent_lineup_inlists.v
+++ b/tests_ok/indent_lineup_inlists.v
@@ -15,11 +15,11 @@ module soft_rst (
                  output hs_async_rst_n // Async reset to host side
                  );
    
-   reg [1:0] state;
+   reg [1:0]        state;
    
    localparam [1:0] IDLE = 2'h0,
-     HALT = 2'h1,
-     RST  = 2'h2,
-     DONE = 2'h3;
+                    HALT = 2'h1,
+                    RST  = 2'h2,
+                    DONE = 2'h3;
    
 endmodule // soft_rst

--- a/tests_ok/indent_param.v
+++ b/tests_ok/indent_param.v
@@ -1,9 +1,9 @@
 module example_block
   #(
-    parameter PARAM    = 1,
-    FOO                = 2,
-    BARFLUG            = 4,
-    G                  = 5,
+    parameter PARAM = 1,
+    FOO = 2,
+    BARFLUG = 4,
+    G = 5,
     )
    (// I/O
     input      reset_n,

--- a/tests_ok/inject_inst_param.v
+++ b/tests_ok/inject_inst_param.v
@@ -1,5 +1,5 @@
 module inject_inst_param;
-   parameter WIDTH = 8;
+   parameter         WIDTH = 8;
    logic [WIDTH-1:0] q;
    logic [WIDTH-1:0] d;
    logic             clk, rst_n;

--- a/tests_ok/inst.v
+++ b/tests_ok/inst.v
@@ -8,11 +8,11 @@ module inst (/*AUTOARG*/
    parameter param1;
    parameter param2;
    
-   input  lower_inb;
-   input  lower_ina;
-   output lower_out;
+   input     lower_inb;
+   input     lower_ina;
+   output    lower_out;
    
-   wire   lower_out = lower_ina | lower_inb;
+   wire      lower_out = lower_ina | lower_inb;
    
 endmodule
 

--- a/tests_ok/lineup.v
+++ b/tests_ok/lineup.v
@@ -1,2 +1,2 @@
 module ocnSwitchClockGen(output reg ocnSwitchClock);
-   parameter   ocnSwitchClockPeriod = 2000;
+   parameter ocnSwitchClockPeriod = 2000;

--- a/tests_ok/params_multiline_msg618_inc.vh
+++ b/tests_ok/params_multiline_msg618_inc.vh
@@ -1,6 +1,6 @@
-parameter
-  // full line comment
-  param1 = 1'b1,  // trailing comment
-  param2 = 1'b0,  /* trailing comment */
-         // full line comment
-  param3 = 1'b1;
+parameter 
+          // full line comment
+          param1 = 1'b1, // trailing comment
+          param2 = 1'b0, /* trailing comment */
+                 // full line comment
+          param3 = 1'b1;

--- a/tests_ok/testcases.v
+++ b/tests_ok/testcases.v
@@ -107,8 +107,8 @@ module testmodule (/*AUTOARG*/
      endcase
    
    parameter READ = 3'b111,
-     //WRITE = 3'b111,
-     CFG = 3'b010;
+             //WRITE = 3'b111,
+             CFG = 3'b010;
    //supply1   one;
    
    always @(/*AUTOSENSE*/in1 or in2) begin
@@ -161,9 +161,9 @@ module darren_jones_2 (/*AUTOARG*/
    input [1:0]  WSTATE;
    output [1:0] next_WSTATE;
    reg [1:0]    next_WSTATE;
-   parameter
-     WIDLE = 0,         // No Manual Write Burst
-     WCB0  = 1;         // 1st of the 4 Manual Write Burst
+   parameter    
+                WIDLE = 0, // No Manual Write Burst
+                WCB0  = 1;              // 1st of the 4 Manual Write Burst
    
    always @ (/*AUTOSENSE*/WSTATE) begin
       next_WSTATE = 2'b0;
@@ -186,9 +186,9 @@ module darren_jones_3 (/*AUTOARG*/
    output      var1;
    reg         var1;
    
-   parameter
-     IDLE = 1,
-     CAS1 = 2;
+   parameter   
+               IDLE = 1,
+               CAS1 = 2;
    
    always @(/*AUTOSENSE*/state) begin
       case (1'b1)

--- a/tests_ok/v2k_localparam.v
+++ b/tests_ok/v2k_localparam.v
@@ -5,7 +5,7 @@ module v2k_localparam;
    localparam X = 10;
    parameter  Y = 10;
    
-   reg z;
+   reg        z;
    
    always @ (/*AS*/) begin
       z = X | Y;

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -2785,6 +2785,8 @@ find the errors."
        "shortreal" "real" "realtime"
        ;; net_type
        "supply0" "supply1" "tri" "triand" "trior" "trireg" "tri0" "tri1" "uwire" "wire" "wand" "wor"
+       ;; parameters
+       "localparam" "parameter" "var"
        ;; misc
        "string" "event" "chandle" "virtual" "enum" "genvar"
        "struct" "union"


### PR DESCRIPTION
This completely solves fontification of parameter declarations. 

As a side effect, indentation behavior is changed as well. Before this, parameter statements (w/o a declaration suffixes) were not being considered for indentation in `verilog-pretty-declarations`.  I believe new behavior is 'correct',  however it leads to failing indentation tests. So merging this would require us to edit `tests_ok` files to account for this behavior. How do we go about doing that? Just blindly replace them with newly generated ones?