### PR TITLE
Enahnce surpport of hideshow,

### DIFF
--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -2712,6 +2712,7 @@ find the errors."
            "\\|\\(\\<clocking\\>\\)"              ;17
            "\\|\\(\\<`[ou]vm_[a-z_]+_begin\\>\\)" ;18
            "\\|\\(\\<`vmm_[a-z_]+_member_begin\\>\\)"
+           "\\|\\(\\<`ifdef\\>\\)"                ;20
 	   ;;
 	   ))
 
@@ -3835,7 +3836,10 @@ Use filename, if current buffer being edited shorten to just buffer name."
         (setq md 3)) ; 3 to get to endsequence in the reg above
        ((match-end 17)
         ;; Search forward for matching endclocking
-        (setq reg "\\(\\<clocking\\>\\)\\|\\(\\<endclocking\\>\\)" )))
+        (setq reg "\\(\\<clocking\\>\\)\\|\\(\\<endclocking\\>\\)" ))
+       ((match-end 20)
+        ;; Search forward for matching `endif
+        (setq reg "\\(\\<`ifdef\\>\\)\\|\\(\\<`endif\\>\\)" )))
       (if (and reg
 	       (forward-word-strictly 1))
 	  (catch 'skip
@@ -4107,9 +4111,13 @@ Key bindings specific to `verilog-mode-map' are:
   (when (boundp 'hs-special-modes-alist)
     (unless (assq 'verilog-mode hs-special-modes-alist)
       (setq hs-special-modes-alist
-            (cons '(verilog-mode "\\<begin\\>" "\\<end\\>" nil
-                                 verilog-forward-sexp-function)
-                  hs-special-modes-alist))))
+            (cons '(verilog-mode
+                    "\\<begin\\>\\|\\<task\\>\\|\\<function\\>\\|\\<class\\>\\|\\<interface\\>\\|\\<fork\\>\\|(\\|`ifdef"
+                    "\\<end\\>\\|\\<endtask\\>\\|\\<endfunction\\>\\|\\<endclass\\>\\|\\<endinterface\\>\\|\\<join\\>\\|)\\|`endif"
+                    nil
+                    verilog-forward-sexp-function)
+                  hs-special-modes-alist))
+      ))
 
   (add-hook 'completion-at-point-functions
             #'verilog-completion-at-point nil 'local)


### PR DESCRIPTION
 Add "`ifdef" into  "verilog-beg-block-re-ordered"
 For my useage, use tab to trigger the hide/show or indent function
(defun my-hideshowvis-fringe ()
  (interactive )
  (end-of-line)
  (if (save-excursion
        (end-of-line 1)
        (or (hs-already-hidden-p)
            (progn
              (forward-char 1)
              (hs-already-hidden-p))))
      (hs-show-block)
    (hs-hide-block)
    ;; (beginning-of-line)
    ))

(defun my-verilog-indent/hs ()
  "work around `electric-verilog-tab', indent or hide/show fring.
If `buffer-read-only' is non-nil, execute `my-hideshowvis-fringe'.
If `electric-verilog-tab' don't change position, execute `my-hideshowvis-fringe'.
"
  (interactive)
  (if (or buffer-read-only
          (let* ((old-position (point))
                 (new-position (progn (electric-verilog-tab)
                                      (point))))
            (= old-position new-position))
          )
      (my-hideshowvis-fringe)))

(define-key verilog-mode-map "\t" 'my-verilog-indent/hs)

We appreciate your contributing to Verilog-Mode.

By contributing you agree this code will be licensed under the GNU Public License.

Please check your github name is set to your real name (click on your avatar icon in upper right, then "settings" then "Name".) This should match your system's ~/.gitconfig user name.
