### PR TITLE
Enhance hide show

### DIFF
--- a/tests/autoinst_ifdef_fredrickson_200503_sub.v
+++ b/tests/autoinst_ifdef_fredrickson_200503_sub.v
@@ -1,15 +1,15 @@
 module autoinst_ifdef_fredrickson_200503_sub
   (input       a,
-   `ifdef TEST
+`ifdef TEST
    input       c,
    output wire d,
-   `endif
+`endif
    output wire b
    );
 
    assign b = a;
-   `ifdef TEST
+`ifdef TEST
    assign d = c;
-   `endif
+`endif
 
 endmodule // define_sub

--- a/tests/indent_ifdef_generate.v
+++ b/tests/indent_ifdef_generate.v
@@ -23,8 +23,8 @@ $display ($stime, " ERROR: CRN1V[%0d] to DP HM %0d CRN1V15 Connection Failed", d
 postError();
 
 end // else: !assert property
-end // block: VGen
 `endif //  `ifdef IO_DDR3
+end // block: VGen
 end // block: DPConnectGen
 endgenerate
 `endif

--- a/tests_ok/autoasciienum_param.v
+++ b/tests_ok/autoasciienum_param.v
@@ -2,15 +2,15 @@
 `ifdef NOTDEFINED
 module just_for_proper_indentation ();
 `endif
-   
-   //Verilint 175 off //WARNING: Unused parameter
-   
-   parameter // synopsys enum En_C14ChipNum
-             EP_C14ChipNum_OASP = 4'h0,
-             EP_C14ChipNum_DLE  = 4'h2,
-             EP_C14ChipNum_TTE  = 4'h3,
-             EP_C14ChipNum_SMM  = 4'h4,
-             EP_C14ChipNum_SMM2 = 4'h5,
-             EP_C14ChipNum_SRP  = 4'h6,
-             EP_C14ChipNum_SPP  = 4'h7,
-             EP_C14ChipNum_RNP  = 4'h8;
+
+//Verilint 175 off //WARNING: Unused parameter
+
+parameter // synopsys enum En_C14ChipNum
+          EP_C14ChipNum_OASP = 4'h0,
+          EP_C14ChipNum_DLE  = 4'h2,
+          EP_C14ChipNum_TTE  = 4'h3,
+          EP_C14ChipNum_SMM  = 4'h4,
+          EP_C14ChipNum_SMM2 = 4'h5,
+          EP_C14ChipNum_SRP  = 4'h6,
+          EP_C14ChipNum_SPP  = 4'h7,
+          EP_C14ChipNum_RNP  = 4'h8;

--- a/tests_ok/indent_ifdef_generate.v
+++ b/tests_ok/indent_ifdef_generate.v
@@ -23,8 +23,8 @@ module m;
                  postError();
                  
               end // else: !assert property
-         end // block: VGen
  `endif //  `ifdef IO_DDR3
+         end // block: VGen
       end // block: DPConnectGen
    endgenerate
 `endif

--- a/tests_ok/inject_inst_endparen.v
+++ b/tests_ok/inject_inst_endparen.v
@@ -20,7 +20,7 @@ module inject_inst_endparen;
                 .rst_n(nreset)
                 /*AUTOINST*/);
 `endif
-   
+
 endmodule
 
 module register (


### PR DESCRIPTION
With following settings, it's able to indent or hideshow code block by tap key `TAB`
``` lisp
(defun my-hideshowvis-fringe ()
  (interactive )
  (end-of-line)
  (if (save-excursion
        (end-of-line 1)
        (or (hs-already-hidden-p)
            (progn
              (forward-char 1)
              (hs-already-hidden-p))))
      (hs-show-block)
    (hs-hide-block)
    ;; (beginning-of-line)
    ))
(defun my-verilog-readonly ()
  "set buffer to read-only if Engineer field of header not equal to `uer-login-name' "
  (interactive)
  (save-excursion
    (goto-line 1)
    (search-forward "Engineer    : " nil t)
    (forward-char)
    (let ((system-user (user-login-name))
          file-author  (symbol-at-point))
      (and (not (string= system-user file-author))
           (require 'git-timemachine)
           (not git-timemachine-mode)
           (read-only-mode 1)
           )
      )))

(defun my-verilog-indent/hs ()
  "work around `electric-verilog-tab', indent or hide/show fring.
If `buffer-read-only' is non-nil, execute `my-hideshowvis-fringe'.
If `electric-verilog-tab' don't change position, execute `my-hideshowvis-fringe'.
"
  (interactive)
  (if (or buffer-read-only
          (let* ((old-position (point))
                 (new-position (progn (electric-verilog-tab)
                                      (point))))
            (= old-position new-position))
          )
      (my-hideshowvis-fringe)))

  (define-key verilog-mode-map "\t" 'my-verilog-indent/hs)

```