### PR TITLE
Fixed AUTONOHOOKUP case where the port is the last input.

### DIFF
--- a/tests/autoinst_autonohookup.v
+++ b/tests/autoinst_autonohookup.v
@@ -1,0 +1,24 @@
+module autoinst_autonohookup (
+                              /*AUTOINPUT*/
+                              /*AUTOOUTPUT*/
+                              // Beginning of automatic outputs (from unused autoinst outputs)
+                              output o1                 // From a2 of a2.v
+                              // End of automatics
+                              );
+   /* a2 AUTO_TEMPLATE (
+    .i1(i1), // AUTONOHOOKUP
+    .o1(o1),
+    ) */
+   a2 a2( /*AUTOINST*/
+          // Outputs
+          .o1                           (o1),                    // Templated
+          // Inputs
+          .i1                           (i1));                   // Templated AUTONOHOOKUP
+endmodule
+
+module a2 (
+           input  i1,
+           output o1
+           );
+endmodule
+

--- a/tests_ok/autoinst_autonohookup.v
+++ b/tests_ok/autoinst_autonohookup.v
@@ -1,0 +1,24 @@
+module autoinst_autonohookup (
+                              /*AUTOINPUT*/
+                              /*AUTOOUTPUT*/
+                              // Beginning of automatic outputs (from unused autoinst outputs)
+                              output o1               // From a2 of a2.v
+                              // End of automatics
+                              );
+   /* a2 AUTO_TEMPLATE (
+    .i1(i1), // AUTONOHOOKUP
+    .o1(o1),
+    ) */
+   a2 a2( /*AUTOINST*/
+          // Outputs
+          .o1                           (o1),                    // Templated
+          // Inputs
+          .i1                           (i1));                   // Templated AUTONOHOOKUP
+endmodule
+
+module a2 (
+           input  i1,
+           output o1
+           );
+endmodule
+

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -11040,7 +11040,7 @@ Intended for internal use inside a
                              'verilog-delete-auto-star-all)
   ;; Remove template comments ... anywhere in case was pasted after AUTOINST removed
   (goto-char (point-min))
-  (while (re-search-forward "\\s-*// \\(Templated\\|Implicit \\.\\*\\)\\([ \tLT0-9]*\\| LHS: .*\\)$" nil t)
+  (while (re-search-forward "\\s-*// \\(Templated\\(\\s-*AUTONOHOOKUP\\)?\\|Implicit \\.\\*\\)\\([ \tLT0-9]*\\| LHS: .*\\)$" nil t)
     (replace-match ""))
 
   ;; Final customize


### PR DESCRIPTION
This PR fixes an issue in #1526 .
When a NOHOOKUP comment is added to an input port which is the last input port in the instantiated module, then each invocation of verilog-mode would append yet another "Templated
AUTONOHOOKUP" comment over and over.

For example:
a3.v
```
module a3(
/*AUTOINPUT*/
/*AUTOOUTPUT*/
);
/* a2 AUTO_TEMPLATE (
  .i1(i1), // AUTONOHOOKUP
  .o1(o1),
) */
a2 a2( /*AUTOINST*/ );
endmodule

module a2 (
  input i1,
  output o1
);
endmodule
```

After 3 consecutive invocations would yield (**please notice you have to right-scroll to see the issue**):
```
module a3(
/*AUTOINPUT*/
/*AUTOOUTPUT*/
// Beginning of automatic outputs (from unused autoinst outputs)
output                  o1                      // From a2 of a2.v
// End of automatics
);
/* a2 AUTO_TEMPLATE (
  .i1(i1), // AUTONOHOOKUP
  .o1(o1),
) */
a2 a2( /*AUTOINST*/
      // Outputs
      .o1                               (o1),                    // Templated
      // Inputs
      .i1                               (i1));                   // Templated AUTONOHOOKUP                       // Templated AUTONOHOOKUP                       // Templated AUTONOHOOKUP
endmodule

module a2 (
  input i1,
  output o1
);
endmodule
```

After this fix, any number of invocations would always yield:
```
module a3(
/*AUTOINPUT*/
/*AUTOOUTPUT*/
// Beginning of automatic outputs (from unused autoinst outputs)
output                  o1                      // From a2 of a2.v
// End of automatics
);
/* a2 AUTO_TEMPLATE (
  .i1(i1), // AUTONOHOOKUP
  .o1(o1),
) */
a2 a2( /*AUTOINST*/
      // Outputs
      .o1                               (o1),                    // Templated
      // Inputs
      .i1                               (i1));                   // Templated AUTONOHOOKUP
endmodule

module a2 (
  input i1,
  output o1
);
endmodule
```