### PR TITLE
Fix indentation on double curly brackets (issue #1719)

### DIFF
--- a/tests/indent_double_curly.v
+++ b/tests/indent_double_curly.v
@@ -1,0 +1,22 @@
+module test;
+always_ff @(posedge clk or negedge rst_n)
+    if (~rst_n)
+begin
+ a <= {(5){1'b0}};
+     a <= 1;
+   end
+
+always_ff @(posedge clk or negedge rst_n)
+if (~rst_n)
+     begin
+   a <= {5{1'b0}};
+ a <= 1;
+      end
+
+always_ff @(posedge clk or negedge rst_n)
+  if (~rst_n)
+    begin
+      a <= {{1'b0,1'b0}};
+a <= 1;
+ end
+  endmodule

--- a/tests_ok/indent_double_curly.v
+++ b/tests_ok/indent_double_curly.v
@@ -1,0 +1,22 @@
+module test;
+   always_ff @(posedge clk or negedge rst_n)
+     if (~rst_n)
+       begin
+          a <= {(5){1'b0}};
+          a <= 1;
+       end
+   
+   always_ff @(posedge clk or negedge rst_n)
+     if (~rst_n)
+       begin
+          a <= {5{1'b0}};
+          a <= 1;
+       end
+   
+   always_ff @(posedge clk or negedge rst_n)
+     if (~rst_n)
+       begin
+          a <= {{1'b0,1'b0}};
+          a <= 1;
+       end
+endmodule

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -6594,7 +6594,7 @@ Return >0 for nested struct."
                        (equal (char-before) ?\;)
                        (equal (char-before) ?\}))
                    ;; skip what looks like bus repetition operator {#{
-                   (not (string-match "^{\\s-*[0-9a-zA-Z_]+\\s-*{" (buffer-substring p (point)))))))))
+                   (not (string-match "^{\\s-*[\\(\\)0-9a-zA-Z_]*\\s-*{" (buffer-substring p (point)))))))))
       (progn
         (let ( (pt (point)) (pass 0))
           (verilog-backward-ws&directives)


### PR DESCRIPTION
verilog-mode.el (verilog-at-constraint-p): Fix regular expression
Add test indent_double_curly.v
