### PR TITLE
Fix indentation on double curly brackets

### DIFF
--- a/tests/indent_double_curly.v
+++ b/tests/indent_double_curly.v
@@ -19,4 +19,18 @@ always_ff @(posedge clk or negedge rst_n)
       a <= {{1'b0,1'b0}};
 a <= 1;
  end
+
+always_ff @(posedge clk or negedge rst_n)
+  if (~rst_n)
+   begin
+       a <= {b, {1'b0,1'b0}};
+ a <= 1;
+        end
+
+always_ff @(posedge clk or negedge rst_n)
+    if (~rst_n)
+     begin
+  a <= {b[1:0], {1'b0,1'b0}};
+   a <= 1;
+       end
   endmodule

--- a/tests_ok/indent_double_curly.v
+++ b/tests_ok/indent_double_curly.v
@@ -19,4 +19,18 @@ module test;
           a <= {{1'b0,1'b0}};
           a <= 1;
        end
+   
+   always_ff @(posedge clk or negedge rst_n)
+     if (~rst_n)
+       begin
+          a <= {b, {1'b0,1'b0}};
+          a <= 1;
+       end
+   
+   always_ff @(posedge clk or negedge rst_n)
+     if (~rst_n)
+       begin
+          a <= {b[1:0], {1'b0,1'b0}};
+          a <= 1;
+       end
 endmodule

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -6603,7 +6603,7 @@ Also move point to constraint."
                        (equal (char-before) ?\;)
                        (equal (char-before) ?\}))
                    ;; skip what looks like bus repetition operator {#{
-                   (not (string-match "^{\\s-*[()0-9a-zA-Z_\\]*\\s-*{"
+                   (not (string-match "^{\\s-*[][()0-9a-zA-Z_,:\\]*\\s-*{"
                                       (buffer-substring p (point)))))))))
       (progn
         (let ( (pt (point)) (pass 0))


### PR DESCRIPTION
* verilog-mode.el (verilog-at-constraint-p): 
  Fix indentation of constructions like `x <= {a, {b, c}};` and `x <= {a[0:1], {b, c}};`.

