### PR TITLE
fix: should able to declare the input as wire

### DIFF
--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -10696,7 +10696,7 @@ When MODI is non-null, also add to modi-cache, for tracking."
                    (or (not (verilog-sig-type sig))
                        (equal "logic" (verilog-sig-type sig))))
               (if (member direction '("input" "output" "inout"))
-                  direction
+                  (concat direction " " verilog-auto-wire-type)
                 "wire"))
              ;;
              ((or (verilog-sig-type sig)


### PR DESCRIPTION
We appreciate your contributing to Verilog-Mode.

By contributing you agree this code will be licensed under the GNU Public License.

Please check your github name is set to your real name (click on your avatar icon in upper right, then "settings" then "Name".) This should match your system's ~/.gitconfig user name.
