### PR TITLE
Fix issue #1321: incorrect indentation of coverpoints

### DIFF
--- a/tests_ok/indent_covergroup_swan.v
+++ b/tests_ok/indent_covergroup_swan.v
@@ -2,43 +2,43 @@ module m;
    bit [0:0] a, b, c;
    covergroup g;
       cp_ab: coverpoint {a,b} {
-                               bins one = {1};
-                               bins two = {2};
-                               }
-        
-        cp_ab_if_c: coverpoint {a,b} iff c {
-           bins one = {1};
-           bins two = {2};
-        }
-        
-        cp_ab_if_c_slice: coverpoint {a,b} iff c[0] {
-                                                     bins one = {1};
-                                                     bins two = {2};
-                                                     }
-          
-          cp_a_if_bc: coverpoint {a,b} iff {b,c} {
-                                                  bins one = {1};
-                                                  bins two = {2};
-                                                  }
-            
-            cp_a_slice : coverpoint a[0] {
-                                          bins one = {1};
-                                          bins two = {2};
-                                          }
-              
-              cp_a_slice_if_b : coverpoint a[0] iff b {
-                 bins one = {1};
-                 bins two = {2};
-              }
-              
-              cp_a_if_b_slice : coverpoint a iff b[0] {
-                                                       bins one = {1};
-                                                       bins two = {2};
-                                                       }
-                
-                cp_a_slice_if_b_slice : coverpoint a[0] iff b[0] {
-                                                                  bins one = {1};
-                                                                  bins two = {2};
-                                                                  }
-                  endgroup
+         bins one = {1};
+         bins two = {2};
+      }
+      
+      cp_ab_if_c: coverpoint {a,b} iff c {
+         bins one = {1};
+         bins two = {2};
+      }
+      
+      cp_ab_if_c_slice: coverpoint {a,b} iff c[0] {
+         bins one = {1};
+         bins two = {2};
+      }
+      
+      cp_a_if_bc: coverpoint {a,b} iff {b,c} {
+         bins one = {1};
+         bins two = {2};
+      }
+      
+      cp_a_slice : coverpoint a[0] {
+         bins one = {1};
+         bins two = {2};
+      }
+      
+      cp_a_slice_if_b : coverpoint a[0] iff b {
+         bins one = {1};
+         bins two = {2};
+      }
+      
+      cp_a_if_b_slice : coverpoint a iff b[0] {
+         bins one = {1};
+         bins two = {2};
+      }
+      
+      cp_a_slice_if_b_slice : coverpoint a[0] iff b[0] {
+         bins one = {1};
+         bins two = {2};
+      }
+   endgroup
 endmodule

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -6646,7 +6646,7 @@ Also move point to constraint."
                        ))
             ;; if first word token not keyword, it maybe the instance name
             ;;   check next word token
-            (if (looking-at "\\<\\w+\\>\\|\\s-*(\\s-*\\S-+")
+            (if (looking-at "\\<\\w+\\>\\|\\s-*[\[(}]\\s-*\\S-+")
                 (progn (verilog-beg-of-statement)
                        (if (and
                             (not (string-match verilog-named-block-re (buffer-substring pt (point)))) ;; Abort if 'begin' keyword is found


### PR DESCRIPTION
This PR fixes issue #1321 

`verilog-at-constraint-p` returned nil when point was at the opening brace of a coverpoint if preceded by [] or {,} expressions. This function is called by `verilog-calc-1` which in turn is called by `verilog-calculate-indent`.
