### PR TITLE
Fix indentation if verilog-indent-lists is nil

### DIFF
--- a/tests/indent_list_nil_generate_for.v
+++ b/tests/indent_list_nil_generate_for.v
@@ -1,0 +1,24 @@
+module foo (
+input wire a,
+input wire b,
+output reg z
+);
+
+localparam CONST=1;
+
+generate
+for (genvar i=0; i<CONST; i++) begin : label
+inst inst(
+.a(a[i]),
+.b(b[i]),
+.z(z[i])
+);
+end : label
+endgenerate
+
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests/indent_list_nil_generate_for2.v
+++ b/tests/indent_list_nil_generate_for2.v
@@ -1,0 +1,23 @@
+module foo (
+input wire a,
+input wire b,
+output reg z
+);
+
+localparam CONST=1;
+
+generate
+for (genvar i=0; i<CONST; i++)
+inst inst(
+.a(a[i]),
+.b(b[i]),
+.z(z[i])
+);
+endgenerate
+
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests/indent_list_nil_generate_if.v
+++ b/tests/indent_list_nil_generate_if.v
@@ -1,0 +1,31 @@
+module foo (
+input wire a,
+input wire b,
+output reg z
+);
+
+parameter VAR = 0;
+
+generate
+if (VAR) begin
+inst inst(
+.a(a),
+.b(b),
+.z(z)
+);
+end
+else begin
+inst2 inst2 (
+.a(a),
+.b(b),
+.z(z)
+);
+end
+endgenerate
+
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests/indent_list_nil_generate_if2.v
+++ b/tests/indent_list_nil_generate_if2.v
@@ -1,0 +1,29 @@
+module foo (
+input wire a,
+input wire b,
+output reg z
+);
+
+parameter VAR = 0;
+
+generate
+if (VAR)
+inst inst(
+.a(a),
+.b(b),
+.z(z)
+);
+else
+inst2 inst2 (
+.a(a),
+.b(b),
+.z(z)
+);
+endgenerate
+
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests/indent_list_nil_params.v
+++ b/tests/indent_list_nil_params.v
@@ -1,0 +1,16 @@
+module foo # (
+parameter A = 0,
+parameter B = 0,
+parameter C = 0,
+parameter D = 0
+)(
+input wire a,
+input wire b,
+output reg z
+);
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests/indent_list_nil_params2.v
+++ b/tests/indent_list_nil_params2.v
@@ -1,0 +1,16 @@
+module foo # (
+parameter A = 0,
+B = 0,
+C = 0,
+D = 0
+)(
+input wire a,
+input wire b,
+output reg z
+);
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests/indent_list_nil_pkg_class.sv
+++ b/tests/indent_list_nil_pkg_class.sv
@@ -1,0 +1,35 @@
+package foo;
+
+class A;
+rand int attribute1;
+rand logic [3:0] attribute2;
+
+constraint values_c {
+attribute1 inside {[0:a]};
+attribute2 inside {[0:15]};
+}
+
+function new (
+int a,
+logic [3:0] b
+);
+this.attribute1 = a;
+this.attribute2 = b;
+endfunction: new
+
+task T1 (
+input int a,
+input logic [3:0] b
+);
+this.attribute1 = a;
+this.attribute2 = b;
+endtask: T1
+
+endclass // A
+
+endpackage // foo
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_generate_for.v
+++ b/tests_ok/indent_list_nil_generate_for.v
@@ -1,0 +1,24 @@
+module foo (
+   input wire a,
+   input wire b,
+   output reg z
+);
+   
+   localparam CONST=1;
+   
+   generate
+      for (genvar i=0; i<CONST; i++) begin : label
+         inst inst(
+            .a(a[i]),
+            .b(b[i]),
+            .z(z[i])
+         );
+      end : label
+   endgenerate
+   
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_generate_for2.v
+++ b/tests_ok/indent_list_nil_generate_for2.v
@@ -1,0 +1,23 @@
+module foo (
+   input wire a,
+   input wire b,
+   output reg z
+);
+   
+   localparam CONST=1;
+   
+   generate
+      for (genvar i=0; i<CONST; i++)
+        inst inst(
+         .a(a[i]),
+         .b(b[i]),
+         .z(z[i])
+      );
+   endgenerate
+   
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_generate_if.v
+++ b/tests_ok/indent_list_nil_generate_if.v
@@ -1,0 +1,31 @@
+module foo (
+   input wire a,
+   input wire b,
+   output reg z
+);
+   
+   parameter VAR = 0;
+   
+   generate
+      if (VAR) begin
+         inst inst(
+            .a(a),
+            .b(b),
+            .z(z)
+         );
+      end
+      else begin
+         inst2 inst2 (
+            .a(a),
+            .b(b),
+            .z(z)
+         );
+      end
+   endgenerate
+   
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_generate_if2.v
+++ b/tests_ok/indent_list_nil_generate_if2.v
@@ -1,0 +1,29 @@
+module foo (
+   input wire a,
+   input wire b,
+   output reg z
+);
+   
+   parameter VAR = 0;
+   
+   generate
+      if (VAR)
+        inst inst(
+           .a(a),
+           .b(b),
+           .z(z)
+        );
+      else
+        inst2 inst2 (
+           .a(a),
+           .b(b),
+           .z(z)
+        );
+   endgenerate
+   
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_params.v
+++ b/tests_ok/indent_list_nil_params.v
@@ -1,0 +1,16 @@
+module foo # (
+   parameter A = 0,
+   parameter B = 0,
+   parameter C = 0,
+   parameter D = 0
+)(
+   input wire a,
+   input wire b,
+   output reg z
+);
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_params2.v
+++ b/tests_ok/indent_list_nil_params2.v
@@ -1,0 +1,16 @@
+module foo # (
+   parameter A = 0,
+   B = 0,
+   C = 0,
+   D = 0
+)(
+   input wire a,
+   input wire b,
+   output reg z
+);
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_pkg_class.sv
+++ b/tests_ok/indent_list_nil_pkg_class.sv
@@ -1,0 +1,35 @@
+package foo;
+   
+class A;
+   rand int         attribute1;
+   rand logic [3:0] attribute2;
+   
+   constraint values_c {
+      attribute1 inside {[0:a]};
+      attribute2 inside {[0:15]};
+   }
+   
+   function new (
+      int         a,
+      logic [3:0] b
+   );
+      this.attribute1 = a;
+      this.attribute2 = b;
+   endfunction: new
+   
+   task T1 (
+      input int         a,
+      input logic [3:0] b
+   );
+      this.attribute1 = a;
+      this.attribute2 = b;
+   endtask: T1
+   
+endclass // A
+   
+endpackage // foo
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_param_1645.v
+++ b/tests_ok/indent_param_1645.v
@@ -1,9 +1,9 @@
 module test();
    submodule #(
-     .param1("HI"),
-     // Pre-fix, attempting to indent here yielded
-     // Scan error: "Unbalanced parenthesis", 50, 1
-     ) modname ();
+      .param1("HI"),
+      // Pre-fix, attempting to indent here yielded
+      // Scan error: "Unbalanced parenthesis", 50, 1
+   ) modname ();
 endmodule
 
 // Local Variables:


### PR DESCRIPTION
This PR implements the indentation suggested in #1703 by setting `verilog-indent-lists` to nil.

Currently, if setting `verilog-indent-lists` to nil there are some indentation issues:
```verilog
module foo # (
parameter A = 0,
parameter B = 0,
parameter C = 0
)(
input wire a,
input wire b,
output reg z
);
endmodule
```
gets indentend to:
```verilog
module foo # (
    parameter A = 0,
	      parameter B = 0,
			parameter C = 0
				  )(
    input wire a,
				  input wire b,
				  output reg z
				  );
endmodule
```
 
The patch also takes into account indentation inside generate blocks and function/tasks arguments.