### PR TITLE
Fix alignment of declaration of interfaces with modports

### DIFF
--- a/tests/indent_sv_interface_mp_bug636.sv
+++ b/tests/indent_sv_interface_mp_bug636.sv
@@ -1,0 +1,10 @@
+// Bug 636
+module mymodule (input logic  reset_n,
+                  input logic  clock,
+                               streambus.sink sink,
+                               streambus.source source,
+                  output logic interrupt_pulse);
+
+    logic [31:0]               test;
+    streambus.source source;
+endmodule

--- a/tests_ok/autoinoutmodule_iface.v
+++ b/tests_ok/autoinoutmodule_iface.v
@@ -3,7 +3,7 @@ module my_core
   (
    /*AUTOINOUTMODULE("autoinoutmodule_iface_sub")*/
    // Beginning of automatic in/out/inouts (from specific module)
-   my_svi.master        my_svi_port
+   my_svi.master my_svi_port
    // End of automatics
    /*AUTOINOUT*/
    /*AUTOINPUT*/

--- a/tests_ok/autoinst_import.v
+++ b/tests_ok/autoinst_import.v
@@ -3,13 +3,13 @@
 module InstModule
   (input      clk,
    svi.master svi_modport,
-   svi        svi_nomodport);
+   svi svi_nomodport);
 endmodule // InstModule
 
 module InstModule1 import mdp_pkg::*;
    (input      clk,
     svi.master svi_modport,
-    svi        svi_nomodport);
+    svi svi_nomodport);
 endmodule
 
 module top;

--- a/tests_ok/autoinst_import2012.v
+++ b/tests_ok/autoinst_import2012.v
@@ -22,8 +22,8 @@ endpackage
 module bus_mux
   import common_pkg::*;
    (// Interfaces
-    bus.slave         bus_master,             // bus from master
-    bus.master        bus_slave[NUM_SLAVES],  // bus to slave
+    bus.slave    bus_master, // bus from master
+    bus.master   bus_slave[NUM_SLAVES], // bus to slave
     // Outputs
     output logic addr_fault_strb
     );

--- a/tests_ok/autoinst_interface.v
+++ b/tests_ok/autoinst_interface.v
@@ -7,7 +7,7 @@ module autoinst_interface
    input logic        clk,
    input logic        reset,
    input logic        start,
-   my_svi.master my_svi_port,
+   my_svi.master      my_svi_port,
    my_svi my_svi_noport,
    my_svi my_svi_noport_upper_decl
    // End of automatics
@@ -21,7 +21,7 @@ module autoinst_interface
    output logic      reset,
    output logic      start,
    input logic [7:0] count,
-   my_svi.master my_svi_port,
+   my_svi.master     my_svi_port,
    my_svi my_svi_noport,
    my_svi my_svi_noport_upper_decl
    // End of automatics

--- a/tests_ok/autoinst_interface_star.v
+++ b/tests_ok/autoinst_interface_star.v
@@ -3,10 +3,10 @@
 module autoinst_interface
   (/*AUTOINOUTMODULE("autoinst_interface_sub")*/
    // Beginning of automatic in/out/inouts (from specific module)
-   output [7:0] count,
-   input        clk,
-   input        reset,
-   input        start,
+   output [7:0]  count,
+   input         clk,
+   input         reset,
+   input         start,
    my_svi.master my_svi_port,
    my_svi my_svi_noport,
    my_svi my_svi_noport_upper_decl
@@ -17,10 +17,10 @@ endmodule
 module autoinst_interface
   (/*AUTOINOUTCOMP("autoinst_interface_sub")*/
    // Beginning of automatic in/out/inouts (from specific module)
-   output      clk,
-   output      reset,
-   output      start,
-   input [7:0] count,
+   output        clk,
+   output        reset,
+   output        start,
+   input [7:0]   count,
    my_svi.master my_svi_port,
    my_svi my_svi_noport,
    my_svi my_svi_noport_upper_decl

--- a/tests_ok/autoinst_interface_sub.v
+++ b/tests_ok/autoinst_interface_sub.v
@@ -13,7 +13,7 @@ module autoinst_interface_sub
    input wire       reset,
    input wire       start,
    output reg [7:0] count,
-   my_svi.master my_svi_port,
+   my_svi.master    my_svi_port,
    my_svi my_svi_noport,
    my_svi my_svi_noport_upper_decl
    );

--- a/tests_ok/autoinst_mplist.sv
+++ b/tests_ok/autoinst_mplist.sv
@@ -9,8 +9,8 @@ module autoinst_mplist
    // Port Declarations
    // --------------------------------------------------------------------------
    
-   input clk,
-   input reset_n,
+   input         clk,
+   input         reset_n,
    
    // Top-level interfaces
    mbl_if.master msg_resp_if

--- a/tests_ok/autoinst_mplist_child.sv
+++ b/tests_ok/autoinst_mplist_child.sv
@@ -7,17 +7,17 @@ module autoinst_mplist_child
    // Port Declarations
    // --------------------------------------------------------------------------
    
-   input        clk,
-   input        reset_n,
-                
-                // Yeah, let's have an interface
-                autoinst_mplist_mbl_if.slave msg_req_if,
-                autoinst_mplist_mbl_if.master msg_resp_if,
+   input                         clk,
+   input                         reset_n,
+   
+   // Yeah, let's have an interface
+   autoinst_mplist_mbl_if.slave  msg_req_if,
+   autoinst_mplist_mbl_if.master msg_resp_if,
    
    // There are likely other signals present, too
-   output logic msg_busy,
-   output logic mem_rd_req,
-   input        mem_rd_gnt
+   output logic                  msg_busy,
+   output logic                  mem_rd_req,
+   input                         mem_rd_gnt
    );
    
    // Really snazzy RTL follows...

--- a/tests_ok/indent_sv_interface_mp_bug636.sv
+++ b/tests_ok/indent_sv_interface_mp_bug636.sv
@@ -1,0 +1,10 @@
+// Bug 636
+module mymodule (input logic  reset_n,
+                 input logic      clock,
+                 streambus.sink   sink,
+                 streambus.source source,
+                 output logic     interrupt_pulse);
+   
+   logic [31:0] test;
+   streambus.source source;
+endmodule


### PR DESCRIPTION
This PR fixes alignment of modport declarations.

Related issue: #636 
