### PR TITLE
Fix alignment of first port declaration

### DIFF
--- a/tests_ok/ExampInoutIn.v
+++ b/tests_ok/ExampInoutIn.v
@@ -1,5 +1,5 @@
 module ExampMain
-  (input i,
+  (input  i,
    output o,
    inout  io);
 endmodule

--- a/tests_ok/ExampInoutModport.v
+++ b/tests_ok/ExampInoutModport.v
@@ -10,7 +10,7 @@ interface ExampIf
 endinterface
 
 module ExampMain
-  ( input clk,
+  ( input       clk,
     /*AUTOINOUTMODPORT("ExampIf", "mp")*/
     // Beginning of automatic in/out/inouts (from modport)
     input       req_val,

--- a/tests_ok/ExampShell.v
+++ b/tests_ok/ExampShell.v
@@ -1,5 +1,5 @@
 module ExampMain
-  (input i,
+  (input  i,
    output o,
    inout  io);
 endmodule

--- a/tests_ok/autoinoutmodport_prefix.v
+++ b/tests_ok/autoinoutmodport_prefix.v
@@ -13,7 +13,7 @@ endinterface
 
 
 module ExampMain
-  ( input clk,
+  ( input       clk,
     
     // Manually declared, so make sure not redeclared
     // Note this is AFTER addition of the prefix

--- a/tests_ok/autoinput_array_bug294.v
+++ b/tests_ok/autoinput_array_bug294.v
@@ -1,9 +1,9 @@
-module mod1(input logic [1:0] reg1[4],
+module mod1(input logic [1:0]             reg1[4],
             input logic                   reg2[5][6],
             input logic [1:0] [3:0] [2:0] reg4);
 endmodule
 
-module mod2(output logic [1:0] reg1[4],
+module mod2(output logic [1:0]             reg1[4],
             output logic [1:0] [3:0] [2:0] reg4);
 endmodule
 

--- a/tests_ok/autoinst_ams_vorwerk.v
+++ b/tests_ok/autoinst_ams_vorwerk.v
@@ -17,21 +17,21 @@ module latch (/*AUTOARG*/
               );
    
 `ifdef __VAMS_ENABLE__
-   output                                                                              (* integer groundSensitivity="gnd "; integer supplySensitivity="vdd "; *) q;
+   output (* integer groundSensitivity="gnd "; integer supplySensitivity="vdd "; *) q;
 `else
-   output    q;
+   output q;
 `endif
    
 `ifdef __VAMS_ENABLE__
-   input                                                                               (* integer groundSensitivity="gnd "; integer supplySensitivity="vdd "; *) en;
+   input (* integer groundSensitivity="gnd "; integer supplySensitivity="vdd "; *) en;
 `else
-   input     en;
+   input en;
 `endif
    
 `ifdef __VAMS_ENABLE__
-   input                                                                              (* integer groundSensitivity="gnd "; integer supplySensitivity="vdd "; *) d;
+   input (* integer groundSensitivity="gnd "; integer supplySensitivity="vdd "; *) d;
 `else
-   input    d;
+   input d;
 `endif
    
 endmodule

--- a/tests_ok/autoinst_array_braket.v
+++ b/tests_ok/autoinst_array_braket.v
@@ -1,4 +1,4 @@
-module sub(output logic [1:-1] oned,
+module sub(output logic [1:-1]               oned,
            output logic [1:-1] [2:-1]        twod,
            output logic [1:-1] [2:-1] [3:-3] threed);
 endmodule

--- a/tests_ok/autoinst_bug373.v
+++ b/tests_ok/autoinst_bug373.v
@@ -4,7 +4,7 @@ typedef struct packed {
 } mystruct_s;
 
 module submod
-  (input logic a_port,
+  (input logic       a_port,
    input logic [4:0] b_bus,
    input             mystruct_s single_struct_is_fine,
    input             mystruct_s [2:0] array_of_struct_is_not,

--- a/tests_ok/autoinst_cmtparen_tennant.sv
+++ b/tests_ok/autoinst_cmtparen_tennant.sv
@@ -3,7 +3,7 @@ typedef node logic;
 module top
   #(parameter COLS = 4
     )
-   ( input logic clk,
+   ( input logic                  clk,
      input logic                  rstb,
      input logic [COLS-1:0]       ival,
      input logic [COLS-1:0][1:0]  idata_some_extra_sig_length,
@@ -78,7 +78,7 @@ module top
 endmodule // top
 
 module sub1
-  ( input logic clk,
+  ( input logic        clk,
     input logic        rstb,
     input logic        ival,
     input logic [1:0]  idata_some_extra_sig_length,
@@ -90,7 +90,7 @@ module sub1
     );
 endmodule // sub
 module sub3
-  ( input logic clk,
+  ( input logic        clk,
     input logic        rstb,
     input logic        ival,
     input logic [1:0]  idata_some_extra_sig_length,
@@ -102,7 +102,7 @@ endmodule // sub
 module sub2
   #(parameter COLS = 4
     )
-   ( input logic clk,
+   ( input logic                   clk,
      input logic                   rstb,
      input logic [COLS-1:0]        ival,
      input logic [COLS-1:0][1:0]   idata_some_extra_sig_length,

--- a/tests_ok/autoinst_interface_sub.v
+++ b/tests_ok/autoinst_interface_sub.v
@@ -9,7 +9,7 @@ interface my_svi;
 endinterface
 
 module autoinst_interface_sub
-  (input wire clk,
+  (input wire       clk,
    input wire       reset,
    input wire       start,
    output reg [7:0] count,

--- a/tests_ok/autoinst_mccoy.v
+++ b/tests_ok/autoinst_mccoy.v
@@ -25,7 +25,7 @@ module top
 endmodule
 
 module xx
-  (input clk,
+  (input        clk,
    
    input        TWI_ia,
    input [15:0] TWI_iw,

--- a/tests_ok/autoinst_modport_param.v
+++ b/tests_ok/autoinst_modport_param.v
@@ -2,14 +2,14 @@
 
 module InstModule
   (svi.master svi_modport,
-   input clk,
+   input      clk,
    svi svi_nomodport);
 endmodule
 
 module InstModule1 #
   (parameter TCQ = 100)
    (svi.master svi_modport,
-    input clk,
+    input      clk,
     svi svi_nomodport);
 endmodule
 

--- a/tests_ok/autoinst_param_type.v
+++ b/tests_ok/autoinst_param_type.v
@@ -44,7 +44,7 @@ module ptype_buf
   #(parameter WIDTH = 1,
     parameter type TYPE_T = logic [WIDTH-1:0])
    (output TYPE_T y,
-    input TYPE_T a);
+    input  TYPE_T a);
    assign y = a;
 endmodule
 

--- a/tests_ok/autoinst_protected.v
+++ b/tests_ok/autoinst_protected.v
@@ -7,7 +7,7 @@ endmodule // foo
 
 module bar(input logic a);
    `protected
-     input            notreally;
+     input notreally;
    `endprotected
      
 `pragma protect begin_protected

--- a/tests_ok/autoinst_tennant.v
+++ b/tests_ok/autoinst_tennant.v
@@ -4,7 +4,7 @@ module top
   #(parameter X=4,
     parameter Y=1)
    
-   (input clk,
+   (input              clk,
     input              rstb,
     
     /*AUTOINPUT("^x.*\|v.*")*/
@@ -65,7 +65,7 @@ endmodule // top
 module xx
   #(parameter X=4,
     parameter Y=1)
-   (input clk,
+   (input              clk,
     input              rstb,
     
     input [X-1:0][1:0] xc,
@@ -85,7 +85,7 @@ endmodule // xx
 module yy
   #(parameter X=4,
     parameter Y=1)
-   (input clk,
+   (input               clk,
     input               rstb,
     
     output [X-1:0][1:0] xc,

--- a/tests_ok/autoinstparam_int.v
+++ b/tests_ok/autoinstparam_int.v
@@ -1,8 +1,8 @@
 module xyz
-  #(parameter int FOO=1, BAR=2,
+  #(parameter int         FOO=1, BAR=2,
     parameter logic [5:0] BLUP=3, ZOT=4,
     parameter             LDWRDS=5)
-   ( input x1, x2,
+   ( input             x1, x2,
      input int         i1, i2,
      input logic [5:0] i3, i4,
      input             i5,

--- a/tests_ok/autologic.sv
+++ b/tests_ok/autologic.sv
@@ -1,7 +1,7 @@
 module top
   #(parameter COLS = 4
     )
-   ( input logic clk,
+   ( input logic                 clk,
      input logic                 rstb,
      input logic [COLS-1:0]      ival,
      input logic [COLS-1:0][1:0] idata_some_extra_sig_length,
@@ -71,7 +71,7 @@ module top
 endmodule
 
 module sub1
-  ( input logic in1a,
+  ( input logic        in1a,
     input logic        in1b,
     output logic       out1a,
     output logic [1:0] out1b
@@ -79,7 +79,7 @@ module sub1
 endmodule
 
 module sub2
-  ( input logic in1a,
+  ( input logic        in1a,
     input logic        in2b,
     input logic        out1a,
     output logic [1:0] out2b

--- a/tests_ok/automodport_ex.v
+++ b/tests_ok/automodport_ex.v
@@ -10,7 +10,7 @@ interface ExampIf
 endinterface
 
 module ExampMain
-  ( input clk,
+  ( input       clk,
     /*AUTOINOUTMODPORT("ExampIf" "mp")*/
     // Beginning of automatic in/out/inouts (from modport)
     input       req_val,

--- a/tests_ok/automodport_full.v
+++ b/tests_ok/automodport_full.v
@@ -1,6 +1,6 @@
 
 module auto_module
-  ( input my_clk,
+  ( input         my_clk,
     input         my_rst_n,
     
     

--- a/tests_ok/autooutput_comma.v
+++ b/tests_ok/autooutput_comma.v
@@ -3,7 +3,7 @@ module top
    /*AUTOOUTPUT*/
    /*AUTOINPUT*/
    // Beginning of automatic inputs (from unused autoinst inputs)
-   input b                      // To child of child.v
+   input              b                 // To child of child.v
    // End of automatics
    );
    

--- a/tests_ok/autooutput_regexp.v
+++ b/tests_ok/autooutput_regexp.v
@@ -5,7 +5,7 @@ module ex_output_every (/*AUTOARG*/
   
   /*AUTOOUTPUT*/
   // Beginning of automatic outputs (from unused autoinst outputs)
-  output                           pixel24_t sub1_out_pixel;            // From i1 of v2k_typedef_yee_sub1.v
+  output pixel24_t sub1_out_pixel;              // From i1 of v2k_typedef_yee_sub1.v
    // End of automatics
    
    v2k_typedef_yee_sub1 i1

--- a/tests_ok/autoreset_regin.v
+++ b/tests_ok/autoreset_regin.v
@@ -24,5 +24,5 @@ module autoreset_regin;
 endmodule
 
 module bar
-  input [7:0]    a;
+  input [7:0] a;
 endmodule

--- a/tests_ok/autosense_gifford.v
+++ b/tests_ok/autosense_gifford.v
@@ -5,7 +5,7 @@ module x (/*AUTOARG*/);
 `define DMC_AG_HADDR_BADDR_BST4_RNG 2:1 // Bank Address Range within Hexabyte Address for 4-Burst
 `define DMC_AG_HADDR_BADDR_BST8_RNG 3:2 // Bank Address Range within Hexabyte Address for 8-Burst
    
-   reg [NumBnks-1:0]             ibnk_sel_s; // Muxed internal bank address subfield of
+   reg [NumBnks-1:0] ibnk_sel_s; // Muxed internal bank address subfield of
    command address
      always @(/*AUTOSENSE*/lio_buscfg_brstlen2_sr or lio_buscfg_brstlen4_sr or m_cdq_haddr_sr)
        begin : PeelIntBnkAddr

--- a/tests_ok/autosense_venkataramanan_begin.v
+++ b/tests_ok/autosense_venkataramanan_begin.v
@@ -5,7 +5,7 @@ module autosense_venkataramanan_begin(/*AUTOARG*/);
    
    always @(/*AUTOSENSE*/b) // I didn't expect to get "i" in AUTOSENSE
      begin : label
-        integer       i, j;
+        integer i, j;
         for (i=0; i< = 3; i = i + 1)
           vec[i] = b;
      end

--- a/tests_ok/autounused.v
+++ b/tests_ok/autounused.v
@@ -1,7 +1,7 @@
 module wbuf
   #(parameter width=1)
    (output [width-1:0] q,
-    input [width-1:0] d);
+    input [width-1:0]  d);
 endmodule
 
 module autounused

--- a/tests_ok/autowire_nocomment.v
+++ b/tests_ok/autowire_nocomment.v
@@ -25,7 +25,7 @@ module top;
 endmodule
 
 module sub2
-  ( input logic in1a,
+  ( input logic        in1a,
     input logic        in1b,
     output logic       out1a,
     output logic [1:0] out1b

--- a/tests_ok/indent_assert_else.v
+++ b/tests_ok/indent_assert_else.v
@@ -1,4 +1,4 @@
-module myassert(input clk,
+module myassert(input        clk,
                 input        reset,
                 input [15:0] data);
    

--- a/tests_ok/indent_assert_property.v
+++ b/tests_ok/indent_assert_property.v
@@ -1,4 +1,4 @@
-module myassert(input clk,
+module myassert(input        clk,
                 input        reset,
                 input [15:0] data);
    

--- a/tests_ok/indent_attributes.v
+++ b/tests_ok/indent_attributes.v
@@ -1,9 +1,9 @@
 module example(out1, out2, out3);
    (* LOC = "D14" *)
-   output out1;
+   output                                          out1;
    /* foobar */ (* LOC = "C15" *) /* jar */ output out2;
    (* LOC = "C16" *)
-   output out3;
+   output                                          out3;
    out1 = 1'b1;
    out2 = 1'b1;
    out3 = 1'b1;

--- a/tests_ok/indent_directives.v
+++ b/tests_ok/indent_directives.v
@@ -9,9 +9,9 @@ module foo;
              );
    input sysclk;
  `ifdef LABEL_B
-   input        bclko;
+   input bclko;
  `endif
-   input        cmode;
+   input cmode;
 `endif
    
    // instead of:
@@ -26,11 +26,11 @@ module foo;
              );
    input sysclk;
  `ifdef LABEL_B
-   input        bclko;
+   input bclko;
  `endif
-   input        cmode;
+   input cmode;
 `endif //  `ifdef LABEL_A
-   reg      a,b;
+   reg a,b;
 `ifdef A
    always @(a) begin
       b = a; // asfSDfsdfsasa

--- a/tests_ok/indent_replicate.v
+++ b/tests_ok/indent_replicate.v
@@ -2,7 +2,7 @@
 module test;
    
    initial begin
-      string         in_str;
+      string in_str;
       
       if (in_str == "") begin : empty_string
          a_string = { 5 {" "}};  // all spaces

--- a/tests_ok/indent_streaming_op.v
+++ b/tests_ok/indent_streaming_op.v
@@ -1,4 +1,4 @@
-module test (input logic clk,
+module test (input logic  clk,
              input logic  a,
              output logic c,
              output byte  d[4]);

--- a/tests_ok/indent_sv_interface_mp_bug636.sv
+++ b/tests_ok/indent_sv_interface_mp_bug636.sv
@@ -1,5 +1,5 @@
 // Bug 636
-module mymodule (input logic  reset_n,
+module mymodule (input logic      reset_n,
                  input logic      clock,
                  streambus.sink   sink,
                  streambus.source source,

--- a/tests_ok/params_multiline_msg618.v
+++ b/tests_ok/params_multiline_msg618.v
@@ -1,6 +1,6 @@
 module testMultiLineParams (/*AUTOARG*/) ;
 `include "params_multiline_msg618_inc.vh"
-   reg                    comboIn, comboOut;
+   reg comboIn, comboOut;
    
    // expect AUTOSENSE to be comboIn only, no params
    always @ ( /*AUTOSENSE*/comboIn) begin

--- a/tests_ok/t_autoinst_def_clk.v
+++ b/tests_ok/t_autoinst_def_clk.v
@@ -24,7 +24,7 @@ module t_autoinst_def_clk
 endmodule // sdc_wombat
 
 module sub
-  (input clk,
+  (input  clk,
    
    input  a,
    input  b,

--- a/tests_ok/task.v
+++ b/tests_ok/task.v
@@ -3,7 +3,7 @@ module foo(input bit [3:0] def,
            input bit [1:0] jkl);
    
    task cba(input bit [3:0] a,
-            input b,
+            input           b,
             c);
    endtask // cba
    task abc(input bit [3:0] def,


### PR DESCRIPTION
This PR fixes #1167 

It also changes the alignment of some variables on the following tests:
- autoinst_ams_vorwerk.v
- autoinst_protected.v
- autooutput_regexp.v
- autoreset_regin.v
- autosense_gifford.v
- autosense_venkataramanan_begin.v
- indent_directives.v
- indent_replicate.v
- params_multiline_msg618.v

To me it seems better alignment but there could be something I am missing about those tests.

Another thing is the mixture of tabs/spaces in the function `verilog-pretty-declarations`. Would it be a good idea to untabify it in a separate commit?

Cheers!
