### PR TITLE
Add a semicolon after module declaration on tests to fix indentation.

### DIFF
--- a/tests/autoinst_param_2d.v
+++ b/tests/autoinst_param_2d.v
@@ -19,7 +19,7 @@ module a(
 	 );
 endmodule
 
-module top (/*AUTOARG*/)
+module top (/*AUTOARG*/);
   /*AUTOINPUT*/
   /*AUTOOUTPUT*/
   /*AUTOWIRE*/

--- a/tests/autoinst_vec_nil.v
+++ b/tests/autoinst_vec_nil.v
@@ -4,7 +4,7 @@ module sub
    output [3:0]        bs);
 endmodule
 
-module t
+module t;
   wire signed [3:0]	as;			// From sub of sub.v
   wire [3:0]		bs;			// From sub of sub.v
 

--- a/tests/autoinst_vec_t.v
+++ b/tests/autoinst_vec_t.v
@@ -4,7 +4,7 @@ module sub
    output [3:0] 	       bs);
 endmodule
 
-module t
+module t;
   wire signed [3:0]	as;			// From sub of sub.v
   wire [3:0]		bs;			// From sub of sub.v
 

--- a/tests/autoinst_vec_unsigned.v
+++ b/tests/autoinst_vec_unsigned.v
@@ -4,7 +4,7 @@ module sub
    output [3:0] 	       bs);
 endmodule
 
-module t
+module t;
   wire signed [3:0]	as;			// From sub of sub.v
   wire [3:0]		bs;			// From sub of sub.v
 

--- a/tests/autowire_merge_bug303.v
+++ b/tests/autowire_merge_bug303.v
@@ -1,7 +1,7 @@
 module TOP (/*AUTOARG*/
    // Outputs
    SIG_NAMEB, SIG_NAMEA
-   )
+   );
    /*AUTOOUTPUT*/
    // Beginning of automatic outputs (from unused autoinst outputs)
    output [223:0]	SIG_NAMEA;		// From A of A.v, ...

--- a/tests_ok/autoinst_param_2d.v
+++ b/tests_ok/autoinst_param_2d.v
@@ -25,10 +25,10 @@ module top (/*AUTOARG*/
             TEST1_my_data_v, TEST1_my_data_av, TEST1_my_data_abv, TEST1_my_data_ab, TEST0_params1,
             TEST0_params0, TEST0_my_data_z, TEST0_my_data_xyz, TEST0_my_data_vv, TEST0_my_data_v,
             TEST0_my_data_av, TEST0_my_data_abv, TEST0_my_data_ab
-            )
-  /*AUTOINPUT*/
-  // Beginning of automatic inputs (from unused autoinst inputs)
-  input [TEST0_AUM-1:0] [TEST0_BUM-1:0] TEST0_my_data_ab;// To a_0 of a.v
+            );
+   /*AUTOINPUT*/
+   // Beginning of automatic inputs (from unused autoinst inputs)
+   input [TEST0_AUM-1:0] [TEST0_BUM-1:0] TEST0_my_data_ab;// To a_0 of a.v
    input [TEST0_AUM-1:0] [TEST0_BUM-1:0] TEST0_my_data_abv [TEST0_VUM];// To a_0 of a.v
    input [TEST0_AUM-1:0]                 TEST0_my_data_av [TEST0_VUM];// To a_0 of a.v
    input                                 TEST0_my_data_v [VUM]; // To a_0 of a.v

--- a/tests_ok/autoinst_vec_nil.v
+++ b/tests_ok/autoinst_vec_nil.v
@@ -4,9 +4,9 @@ module sub
    output [3:0]        bs);
 endmodule
 
-module t
-  wire signed [3:0] as; // From sub of sub.v
-   wire [3:0] bs;                       // From sub of sub.v
+module t;
+   wire signed [3:0] as; // From sub of sub.v
+   wire [3:0]        bs;                        // From sub of sub.v
    
    sub sub (/*AUTOINST*/
             // Outputs

--- a/tests_ok/autoinst_vec_t.v
+++ b/tests_ok/autoinst_vec_t.v
@@ -4,9 +4,9 @@ module sub
    output [3:0]        bs);
 endmodule
 
-module t
-  wire signed [3:0] as; // From sub of sub.v
-   wire [3:0] bs;                       // From sub of sub.v
+module t;
+   wire signed [3:0] as; // From sub of sub.v
+   wire [3:0]        bs;                        // From sub of sub.v
    
    sub sub (/*AUTOINST*/
             // Outputs

--- a/tests_ok/autoinst_vec_unsigned.v
+++ b/tests_ok/autoinst_vec_unsigned.v
@@ -4,9 +4,9 @@ module sub
    output [3:0]        bs);
 endmodule
 
-module t
-  wire signed [3:0] as; // From sub of sub.v
-   wire [3:0] bs;                       // From sub of sub.v
+module t;
+   wire signed [3:0] as; // From sub of sub.v
+   wire [3:0]        bs;                        // From sub of sub.v
    
    sub sub (/*AUTOINST*/
             // Outputs

--- a/tests_ok/autowire_merge_bug303.v
+++ b/tests_ok/autowire_merge_bug303.v
@@ -1,10 +1,10 @@
 module TOP (/*AUTOARG*/
             // Outputs
             SIG_NAMEB, SIG_NAMEA
-            )
-  /*AUTOOUTPUT*/
-  // Beginning of automatic outputs (from unused autoinst outputs)
-  output [223:0]     SIG_NAMEA; // From A of A.v, ...
+            );
+   /*AUTOOUTPUT*/
+   // Beginning of automatic outputs (from unused autoinst outputs)
+   output [223:0]     SIG_NAMEA; // From A of A.v, ...
    output [FOO*4-2:0] SIG_NAMEB;                // From C of C.v
    // End of automatics
    /*AUTOINPUT*/


### PR DESCRIPTION
Hi,

This PR is done as a request on #1775 to split changes not related to comment aligning in a different commit.

A colon was missing on 5 tests after module declaration and first line of variable declarations was being indented incorrectly.
