### PR TITLE
Add indentation ignore of multiline defines and custom regexps

### DIFF
--- a/tests/indent_macro_comment.v
+++ b/tests/indent_macro_comment.v
@@ -39,3 +39,7 @@
                            // the indentation this time; but the indentation
                            // returned to (v2) as set by that sign in `define TEMPB
 `endif
+
+// Local Variables:
+// verilog-indent-ignore-multiline-defines: nil
+// End:

--- a/tests/indent_macro_ignore_multiline.sv
+++ b/tests/indent_macro_ignore_multiline.sv
@@ -1,0 +1,59 @@
+// Issue 1082
+
+`define drive_agt(AGT_ID) \
+  begin \
+      some_agt_seq seq; \
+      seq = some_agt_seq::type_id::create \
+                 (.name({"some_agt_seq_",$sformatf("%0d", AGT_ID)}), \
+                  .contxt(get_full_name())); \
+      seq.start(env.adc_agt[AGT_ID].sqr_l1); \
+  end
+
+
+  `define foo(ARG) \
+     begin \
+       $display(\"Bar\"); \
+       $display(\"Baz\"); \
+     end
+
+
+`define foo(ARG) \
+     begin \
+         $display(\"Bar\"); \
+         $display(\"Baz\"); \
+     end
+
+
+// Indentation should also ignore multiline macros with trailing whitespaces
+`define foo(ARG) \       
+     begin \    
+         $display(\"Bar\"); \       
+         $display(\"Baz\"); \  
+     end
+
+
+
+// Some example module to check that the rest of indentation works fine
+module ram_controller ();
+
+ram_sp_sr_sw #(
+.DATA_WIDTH(16),
+.ADDR_WIDTH(8),
+.RAM_DEPTH(256)
+) ram (
+clk,
+address,
+data,
+cs,
+we,
+oe
+)
+;
+
+endmodule
+
+
+
+// Local Variables:
+// verilog-indent-ignore-multiline-defines: t
+// End:

--- a/tests/indent_macro_ignore_regexp.sv
+++ b/tests/indent_macro_ignore_regexp.sv
@@ -1,0 +1,42 @@
+// Ignore indentation for outshine header lines that start with // *
+
+// * Header1
+   // * Header2
+      // * Header3
+         // ** SubHeader3
+
+
+// * Header1
+   // * Header2
+// * Header3
+          // ** SubHeader3
+
+                             // * Header1
+        // * Header2
+                                                   // * Header3
+             // ** SubHeader3
+
+
+// Some example module to check that the rest of indentation works fine
+module ram_controller ();
+
+ram_sp_sr_sw #(
+.DATA_WIDTH(16),
+.ADDR_WIDTH(8),
+.RAM_DEPTH(256)
+) ram (
+clk,
+address,
+data,
+cs,
+we,
+oe
+)
+;
+
+endmodule
+
+
+// Local Variables:
+// verilog-indent-ignore-regexp: "// \\*"
+// End:

--- a/tests/label_macro.v
+++ b/tests/label_macro.v
@@ -20,4 +20,5 @@ endclass
 // Local Variables:
 // verilog-minimum-comment-distance: 1
 // verilog-auto-endcomments: t
+// verilog-indent-ignore-multiline-defines: nil
 // End:

--- a/tests_ok/indent_macro_comment.v
+++ b/tests_ok/indent_macro_comment.v
@@ -39,3 +39,7 @@
 // the indentation this time; but the indentation
 // returned to (v2) as set by that sign in `define TEMPB
 `endif
+
+// Local Variables:
+// verilog-indent-ignore-multiline-defines: nil
+// End:

--- a/tests_ok/indent_macro_ignore_multiline.sv
+++ b/tests_ok/indent_macro_ignore_multiline.sv
@@ -1,0 +1,59 @@
+// Issue 1082
+
+`define drive_agt(AGT_ID) \
+  begin \
+      some_agt_seq seq; \
+      seq = some_agt_seq::type_id::create \
+                 (.name({"some_agt_seq_",$sformatf("%0d", AGT_ID)}), \
+                  .contxt(get_full_name())); \
+      seq.start(env.adc_agt[AGT_ID].sqr_l1); \
+  end
+
+
+  `define foo(ARG) \
+     begin \
+       $display(\"Bar\"); \
+       $display(\"Baz\"); \
+     end
+
+
+`define foo(ARG) \
+     begin \
+         $display(\"Bar\"); \
+         $display(\"Baz\"); \
+     end
+
+
+// Indentation should also ignore multiline macros with trailing whitespaces
+`define foo(ARG) \
+     begin \
+         $display(\"Bar\"); \
+         $display(\"Baz\"); \
+     end
+
+
+
+// Some example module to check that the rest of indentation works fine
+module ram_controller ();
+   
+   ram_sp_sr_sw #(
+                  .DATA_WIDTH(16),
+                  .ADDR_WIDTH(8),
+                  .RAM_DEPTH(256)
+                  ) ram (
+                         clk,
+                         address,
+                         data,
+                         cs,
+                         we,
+                         oe
+                         )
+     ;
+   
+endmodule
+
+
+
+// Local Variables:
+// verilog-indent-ignore-multiline-defines: t
+// End:

--- a/tests_ok/indent_macro_ignore_regexp.sv
+++ b/tests_ok/indent_macro_ignore_regexp.sv
@@ -1,0 +1,42 @@
+// Ignore indentation for outshine header lines that start with // *
+
+// * Header1
+   // * Header2
+      // * Header3
+         // ** SubHeader3
+
+
+// * Header1
+   // * Header2
+// * Header3
+          // ** SubHeader3
+
+                             // * Header1
+        // * Header2
+                                                   // * Header3
+             // ** SubHeader3
+
+
+// Some example module to check that the rest of indentation works fine
+module ram_controller ();
+   
+   ram_sp_sr_sw #(
+                  .DATA_WIDTH(16),
+                  .ADDR_WIDTH(8),
+                  .RAM_DEPTH(256)
+                  ) ram (
+                         clk,
+                         address,
+                         data,
+                         cs,
+                         we,
+                         oe
+                         )
+     ;
+   
+endmodule
+
+
+// Local Variables:
+// verilog-indent-ignore-regexp: "// \\*"
+// End:

--- a/tests_ok/label_macro.v
+++ b/tests_ok/label_macro.v
@@ -20,4 +20,5 @@ endclass // c
 // Local Variables:
 // verilog-minimum-comment-distance: 1
 // verilog-auto-endcomments: t
+// verilog-indent-ignore-multiline-defines: nil
 // End:

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -679,6 +679,18 @@ Set to 0 to have all directives start at the left side of the screen."
   :type 'integer)
 (put 'verilog-indent-level-directive 'safe-local-variable #'integerp)
 
+(defcustom verilog-indent-ignore-multiline-defines t
+  "Non-nil means ignore indentation on lines that are part of a multiline define."
+  :group 'verilog-mode-indent
+  :type 'boolean)
+(put 'verilog-indent-ignore-multiline-defines 'safe-local-variable #'verilog-booleanp)
+
+(defcustom verilog-indent-ignore-regexp nil
+  "Regexp that matches lines that should be ignored for indentation."
+  :group 'verilog-mode-indent
+  :type 'boolean)
+(put 'verilog-indent-ignore-regexp 'safe-local-variable #'stringp)
+
 (defcustom verilog-cexp-indent 2
   "Indentation of Verilog statements split across lines."
   :group 'verilog-mode-indent
@@ -4015,6 +4027,10 @@ Variables controlling indentation/edit style:
    function keyword.
  `verilog-indent-level-directive'     (default 1)
    Indentation of \\=`ifdef/\\=`endif blocks.
+ `verilog-indent-ignore-multiline-defines' (default t)
+   Non-nil means ignore indentation on lines that are part of a multiline define.
+ `verilog-indent-ignore-regexp'     (default nil
+   Regexp that matches lines that should be ignored for indentation.
  `verilog-cexp-indent'              (default 1)
    Indentation of Verilog statements broken across lines i.e.:
       if (a)
@@ -6911,6 +6927,9 @@ Only look at a few lines to determine indent level."
   (let ((type (car indent-str))
 	(ind (car (cdr indent-str))))
     (cond
+     (; handle indentation ignoring
+      (verilog-indent-ignore-p)
+      nil)
      (; handle continued exp
       (eq type 'cexp)
       (let ((here (point)))
@@ -7567,6 +7586,18 @@ Region is defined by B and ENDPOS."
     (backward-char 6)
     (insert
      (format "%s %d" type val))))
+
+(defun verilog-indent-ignore-p ()
+  "Return non-nil if current line should ignore indentation."
+  (or (and verilog-indent-ignore-multiline-defines ; Ignore multiline defines
+           (or (looking-at ".*\\\\\\s-*$")         ; Line with multiline define, ends with "\" or "\" plus trailing whitespace
+               (save-excursion                     ; Last line after multiline define
+                 (verilog-backward-syntactic-ws)
+                 (unless (bobp)
+                   (backward-char))
+                 (looking-at "\\\\"))))
+      (and verilog-indent-ignore-regexp ; Ignore lines according to specified regexp
+           (looking-at verilog-indent-ignore-regexp))))
 
 
 ;;; Completion:
@@ -15086,6 +15117,8 @@ Files are checked based on `verilog-library-flags'."
        verilog-indent-begin-after-if
        verilog-indent-class-inside-pkg
        verilog-indent-declaration-macros
+       verilog-indent-ignore-multiline-defines
+       verilog-indent-ignore-regexp
        verilog-indent-level
        verilog-indent-level-behavioral
        verilog-indent-level-declaration

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -7589,9 +7589,10 @@ Region is defined by B and ENDPOS."
 
 (defun verilog-indent-ignore-p ()
   "Return non-nil if current line should ignore indentation."
-  (or (and verilog-indent-ignore-multiline-defines ; Ignore multiline defines
-           (or (looking-at ".*\\\\\\s-*$")         ; Line with multiline define, ends with "\" or "\" plus trailing whitespace
-               (save-excursion                     ; Last line after multiline define
+  (or (and verilog-indent-ignore-multiline-defines
+           ;; Line with multiline define, ends with "\" or "\" plus trailing whitespace
+           (or (looking-at ".*\\\\\\s-*$")
+               (save-excursion  ; Last line after multiline define
                  (verilog-backward-syntactic-ws)
                  (unless (bobp)
                    (backward-char))


### PR DESCRIPTION
Hi,

This PR adds support to ignore  indentation of multiline defines and custom regexps.

Related issues: #1082, #922, #885