### PR TITLE
Add variable to adjust aligned comment distance in declarations.

### DIFF
--- a/tests/align_decl_comments_spacing_0.sv
+++ b/tests/align_decl_comments_spacing_0.sv
@@ -1,0 +1,91 @@
+// Issue #435
+module foo
+(
+                                // Global Interface Signals
+ input clk, // core system clock
+ input signal1, // Comment here which should be at "comment-column"
+ input signal_long2, // Comment here which should be at "comment-column"
+ input sig3,                    // Here, I've hit "tab" twice and this line is correct
+ input s4, // Comment here which should be at "comment-column"
+ input reset_L,         // module reset: global register
+);
+endmodule // foo
+
+
+// Issue #898
+module my_module
+ ( input a, // sig a
+    input bc, // sig bc
+    input d // sig d
+ );
+//
+endmodule
+
+
+// Issue #922
+module foo
+(input logic clk, // Added with respect to #922 to test alignment
+input my_pkg::user_type keep_type_way_left, //.  <==Keep-indent marker
+output logic done); // Added with respect to #922 to test alignment
+
+import my_pkg::*; // Added with respect to #922 to test alignment
+logic [7:0] city_bus; // Added with respect to #922 to test alignment
+var user_type keep_type_also_way_left; //.  <==Keep-indent marker
+endmodule
+
+
+// Issue #1157
+module top
+(
+//Inputs
+input CLK, //System Clock
+input RST, //Active High Reset
+input [3:0] CONTROL, //Control decoder.
+
+//Outputs
+output reg [7:0] LIVE_DATA, //1 byte data
+output VALID //Valid Flag
+);
+endmodule
+
+
+// Other tests (some of them not working @ June 2022)
+module foo
+(
+// This comment should NOT get aligned
+input logic a1,// comment
+input logic [1:0] a2,//comment
+input logic a3,
+input logic a4,
+input logic [1:0] a5,                  //comment
+output logic z1,      //    comment
+input logic [1:0] z2 /* comment */
+   // This comment should NOT get aligned
+);
+
+localparam IDLE = 0,// '01
+READ = 1,// '02
+THINK = 2,// '04
+SEND = 3,// '08
+WAIT = 4,// '10
+GET_ACK = 5,// '20
+WAIT_BUS = 6;// '40
+
+// This comment should NOT get aligned
+logic s1;// comment
+logic [1:0] s2;//comment
+logic s3;
+logic s4;
+logic [1:0] s5;                  //comment
+logic t1;      //    comment
+logic [1:0] t2; /* comment */
+logic [1:0] /* embedded comment should NOT get aligned */ t3;
+   // This comment should NOT get aligned
+ /* This multiline comment
+      should NOT get aligned */
+endmodule
+
+// Local Variables:
+// verilog-align-comment-distance: 0
+// End:
+

--- a/tests/align_decl_comments_spacing_10.sv
+++ b/tests/align_decl_comments_spacing_10.sv
@@ -1,0 +1,91 @@
+// Issue #435
+module foo
+(
+                                // Global Interface Signals
+ input clk, // core system clock
+ input signal1, // Comment here which should be at "comment-column"
+ input signal_long2, // Comment here which should be at "comment-column"
+ input sig3,                    // Here, I've hit "tab" twice and this line is correct
+ input s4, // Comment here which should be at "comment-column"
+ input reset_L,         // module reset: global register
+);
+endmodule // foo
+
+
+// Issue #898
+module my_module
+ ( input a, // sig a
+    input bc, // sig bc
+    input d // sig d
+ );
+//
+endmodule
+
+
+// Issue #922
+module foo
+(input logic clk, // Added with respect to #922 to test alignment
+input my_pkg::user_type keep_type_way_left, //.  <==Keep-indent marker
+output logic done); // Added with respect to #922 to test alignment
+
+import my_pkg::*; // Added with respect to #922 to test alignment
+logic [7:0] city_bus; // Added with respect to #922 to test alignment
+var user_type keep_type_also_way_left; //.  <==Keep-indent marker
+endmodule
+
+
+// Issue #1157
+module top
+(
+//Inputs
+input CLK, //System Clock
+input RST, //Active High Reset
+input [3:0] CONTROL, //Control decoder.
+
+//Outputs
+output reg [7:0] LIVE_DATA, //1 byte data
+output VALID //Valid Flag
+);
+endmodule
+
+
+// Other tests (some of them not working @ June 2022)
+module foo
+(
+// This comment should NOT get aligned
+input logic a1,// comment
+input logic [1:0] a2,//comment
+input logic a3,
+input logic a4,
+input logic [1:0] a5,                  //comment
+output logic z1,      //    comment
+input logic [1:0] z2 /* comment */
+   // This comment should NOT get aligned
+);
+
+localparam IDLE = 0,// '01
+READ = 1,// '02
+THINK = 2,// '04
+SEND = 3,// '08
+WAIT = 4,// '10
+GET_ACK = 5,// '20
+WAIT_BUS = 6;// '40
+
+// This comment should NOT get aligned
+logic s1;// comment
+logic [1:0] s2;//comment
+logic s3;
+logic s4;
+logic [1:0] s5;                  //comment
+logic t1;      //    comment
+logic [1:0] t2; /* comment */
+logic [1:0] /* embedded comment should NOT get aligned */ t3;
+   // This comment should NOT get aligned
+ /* This multiline comment
+      should NOT get aligned */
+endmodule
+
+// Local Variables:
+// verilog-align-comment-distance: 10
+// End:
+

--- a/tests_ok/align_decl_comments_spacing_0.sv
+++ b/tests_ok/align_decl_comments_spacing_0.sv
@@ -1,0 +1,91 @@
+// Issue #435
+module foo
+  (
+   // Global Interface Signals
+   input clk,         // core system clock
+   input signal1,     // Comment here which should be at "comment-column"
+   input signal_long2,// Comment here which should be at "comment-column"
+   input sig3,        // Here, I've hit "tab" twice and this line is correct
+   input s4,          // Comment here which should be at "comment-column"
+   input reset_L,     // module reset: global register
+   );
+endmodule // foo
+
+
+// Issue #898
+module my_module
+  ( input a, // sig a
+    input bc,// sig bc
+    input d  // sig d
+    );
+   //
+endmodule
+
+
+// Issue #922
+module foo
+  (input logic  clk,                                 // Added with respect to #922 to test alignment
+   input        my_pkg::user_type keep_type_way_left,//.  <==Keep-indent marker
+   output logic done);                               // Added with respect to #922 to test alignment
+   
+   import my_pkg::*; // Added with respect to #922 to test alignment
+   logic [7:0] city_bus;                         // Added with respect to #922 to test alignment
+   var         user_type keep_type_also_way_left;//.  <==Keep-indent marker
+endmodule
+
+
+// Issue #1157
+module top
+  (
+   //Inputs
+   input            CLK,      //System Clock
+   input            RST,      //Active High Reset
+   input [3:0]      CONTROL,  //Control decoder.
+   
+   //Outputs
+   output reg [7:0] LIVE_DATA,//1 byte data
+   output           VALID     //Valid Flag
+   );
+endmodule
+
+
+// Other tests (some of them not working @ June 2022)
+module foo
+  (
+   // This comment should NOT get aligned
+   input logic       a1,// comment
+   input logic [1:0] a2,//comment
+   input logic       a3,
+   input logic       a4,
+   input logic [1:0] a5,//comment
+   output logic      z1,//    comment
+   input logic [1:0] z2 /* comment */
+   // This comment should NOT get aligned
+   );
+   
+   localparam  IDLE = 0,// '01
+               READ = 1,// '02
+               THINK = 2,// '04
+               SEND = 3,// '08
+               WAIT = 4,// '10
+               GET_ACK = 5,// '20
+               WAIT_BUS = 6;// '40
+   
+   // This comment should NOT get aligned
+   logic       s1;      // comment
+   logic [1:0] s2;      //comment
+   logic       s3;
+   logic       s4;
+   logic [1:0] s5;      //comment
+   logic       t1;      //    comment
+   logic [1:0] t2;      /* comment */
+   logic [1:0] /* embedded comment should NOT get aligned */ t3;
+   // This comment should NOT get aligned
+   /* This multiline comment
+    should NOT get aligned */
+endmodule
+
+// Local Variables:
+// verilog-align-comment-distance: 0
+// End:
+

--- a/tests_ok/align_decl_comments_spacing_10.sv
+++ b/tests_ok/align_decl_comments_spacing_10.sv
@@ -1,0 +1,91 @@
+// Issue #435
+module foo
+  (
+   // Global Interface Signals
+   input clk,                   // core system clock
+   input signal1,               // Comment here which should be at "comment-column"
+   input signal_long2,          // Comment here which should be at "comment-column"
+   input sig3,                  // Here, I've hit "tab" twice and this line is correct
+   input s4,                    // Comment here which should be at "comment-column"
+   input reset_L,               // module reset: global register
+   );
+endmodule // foo
+
+
+// Issue #898
+module my_module
+  ( input a,           // sig a
+    input bc,          // sig bc
+    input d            // sig d
+    );
+   //
+endmodule
+
+
+// Issue #922
+module foo
+  (input logic  clk,                                           // Added with respect to #922 to test alignment
+   input        my_pkg::user_type keep_type_way_left,          //.  <==Keep-indent marker
+   output logic done);                                         // Added with respect to #922 to test alignment
+   
+   import my_pkg::*; // Added with respect to #922 to test alignment
+   logic [7:0] city_bus;                                   // Added with respect to #922 to test alignment
+   var         user_type keep_type_also_way_left;          //.  <==Keep-indent marker
+endmodule
+
+
+// Issue #1157
+module top
+  (
+   //Inputs
+   input            CLK,                //System Clock
+   input            RST,                //Active High Reset
+   input [3:0]      CONTROL,            //Control decoder.
+   
+   //Outputs
+   output reg [7:0] LIVE_DATA,          //1 byte data
+   output           VALID               //Valid Flag
+   );
+endmodule
+
+
+// Other tests (some of them not working @ June 2022)
+module foo
+  (
+   // This comment should NOT get aligned
+   input logic       a1,          // comment
+   input logic [1:0] a2,          //comment
+   input logic       a3,
+   input logic       a4,
+   input logic [1:0] a5,          //comment
+   output logic      z1,          //    comment
+   input logic [1:0] z2           /* comment */
+   // This comment should NOT get aligned
+   );
+   
+   localparam  IDLE = 0,          // '01
+               READ = 1,// '02
+               THINK = 2,// '04
+               SEND = 3,// '08
+               WAIT = 4,// '10
+               GET_ACK = 5,// '20
+               WAIT_BUS = 6;// '40
+   
+   // This comment should NOT get aligned
+   logic       s1;                // comment
+   logic [1:0] s2;                //comment
+   logic       s3;
+   logic       s4;
+   logic [1:0] s5;                //comment
+   logic       t1;                //    comment
+   logic [1:0] t2;                /* comment */
+   logic [1:0] /* embedded comment should NOT get aligned */ t3;
+   // This comment should NOT get aligned
+   /* This multiline comment
+    should NOT get aligned */
+endmodule
+
+// Local Variables:
+// verilog-align-comment-distance: 10
+// End:
+

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -755,6 +755,13 @@ Otherwise else is lined up with first character on line holding matching if."
   :type 'boolean)
 (put 'verilog-align-declaration-comments 'safe-local-variable #'verilog-booleanp)
 
+(defcustom verilog-align-comment-distance 1
+  "Distance (in spaces) between longest declaration and comments.
+Only works if `verilog-align-declaration-comments' is non-nil."
+  :group 'verilog-mode-indent
+  :type 'integer)
+(put 'verilog-align-comment-distance 'safe-local-variable #'integerp)
+
 (defcustom verilog-minimum-comment-distance 10
   "Minimum distance (in lines) between begin and end required before a comment.
 Setting this variable to zero results in every end acquiring a comment; the
@@ -4068,6 +4075,9 @@ Variables controlling indentation/edit style:
    comments in tight quarters.
  `verilog-align-declaration-comments' (default t)
    Non-nil means align declaration comments.
+ `verilog-align-comment-distance' (default 1)
+   Distance (in spaces) between longest declaration and comments.
+   Only works if `verilog-align-declaration-comments' is non-nil.
  `verilog-auto-lineup'              (default `declarations')
    List of contexts where auto lineup of code should be done.
 
@@ -7313,7 +7323,7 @@ Be verbose about progress unless optional QUIET set."
                   (when (verilog-search-comment-in-declaration e)
                     (goto-char (match-beginning 0))
                     (delete-horizontal-space)
-                    (indent-to comm-ind 1))))))
+                    (indent-to (1- (+ comm-ind verilog-align-comment-distance))))))))
         ;; Exit
 	(unless quiet (message ""))))))
 
@@ -15064,6 +15074,7 @@ Files are checked based on `verilog-library-flags'."
      '(
        verilog-active-low-regexp
        verilog-after-save-font-hook
+       verilog-align-comment-distance
        verilog-align-declaration-comments
        verilog-align-ifelse
        verilog-assignment-delay


### PR DESCRIPTION
Hi,

This PR adds the customizable variable `verilog-declaration-comments-distance` to adjust the spacing between the longest declaration and the beginning of aligned comments, previously fixed to 1 space.

I also added two tests, similar to the `align_decl_comments.sv` test, but with spacing set to 0 and 10 respectively.