### PR TITLE
Fix verilog-pretty-expr on declarations and update related tests

### DIFF
--- a/tests_ok/escape_a.v
+++ b/tests_ok/escape_a.v
@@ -8,7 +8,7 @@ module escape_a (/*AUTOARG*/
    output \o[2] ;
    input  \i&e; ;
    
-   wire \o[10] = \i&e; ;
-   wire \o[2]  = \i&e; ;
+   wire   \o[10] = \i&e; ;
+   wire   \o[2]  = \i&e; ;
    
 endmodule


### PR DESCRIPTION
Hi,

This PR fixes the function `verilog-pretty-expr` when cursor is at a declaration. 

It adds some cleaning to the `verilog-indent-declaration`, replacing some ifs without an else clause with `(when condition ...)` and indenting accordingly.

It also includes additional checks to set proper boundaries when looking for previous declaration as a template, as part of the process of the expression prettifying. Otherwise, declarations outside of a module port list get aligned with expressions inside module port lists, e.g:
```verilog
module ExampOutputEvery (
                         /*AUTOOUTPUTEVERY*/
                         // Beginning of automatic outputs (every signal)
                         output o,
                         output tempa,
                         output tempb,
                         // End of automatics
                         input  i
                         );
   wire tempa = i;
   wire tempb = tempa;
   wire o     = tempb;
endmodule
```

This would be the result without the checks at `verilog-indent-declaration` after updating the declaration regexp:
```verilog
module ExampOutputEvery (
                         /*AUTOOUTPUTEVERY*/
                         // Beginning of automatic outputs (every signal)
                         output o,
                         output tempa,
                         output tempb,
                         // End of automatics
                         input  i
                         );
    wire                        tempa = i;
    wire                        tempb = tempa;
    wire                        o     = tempb;
endmodule
``` 

Lastly, the 0test.el file is changed so that `verilog-pretty-expr` is run after `verilog-pretty-declarations`, since the latter removes spacing after the declaration, canceling the effect of `verilog-pretty-expr`.

The tests are updated and it seems to work fine.

Thanks!