### PR TITLE
Fix indentation of instances and declarations after 'begin'

### DIFF
--- a/tests_ok/indent_genmod.v
+++ b/tests_ok/indent_genmod.v
@@ -6,11 +6,11 @@ module indent;
       // Here, AUTOINST line indents incorrectly indents way too far the the right
       // ( below indents after = above, which is incorrect
       subindent s
-                          (/*AUTOINST*/
-                           // Outputs
-                           .y                   (y),
-                           // Inputs
-                           .a                   (a));
+        (/*AUTOINST*/
+         // Outputs
+         .y                     (y),
+         // Inputs
+         .a                     (a));
    end endgenerate
    
    // Without the '=0', the AUTOINST line indents properly

--- a/tests_ok/indent_replicate.v
+++ b/tests_ok/indent_replicate.v
@@ -11,7 +11,7 @@ module test;
    
    initial begin
       string in_str;
-      int width   = 5;
+      int    width = 5;
       
       if (in_str == "") begin : empty_string
          a_string = { width {" "}};  // all spaces

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -4722,10 +4722,8 @@ Uses `verilog-scan' cache."
                 (= (preceding-char) ?\;)
 		(progn
 		  (verilog-backward-token)
-		  (if verilog-indent-lists
-                      (looking-at verilog-ends-re)
-                    (or (looking-at verilog-ends-re)
-                        (looking-at "begin")))))
+                  (or (looking-at verilog-ends-re)
+                      (looking-at "begin"))))
             (progn
               (goto-char pt)
               (throw 'done t)))))


### PR DESCRIPTION
Hi,

While working on PR #1780 I noticed that a declaration that should get aligned for `indent_replicate.v` actually did not. After a bit of debugging I found the issue was caused by the declaration being right after the `begin` keyword if `verilog-indent-lists` was set to t (its default value). 

I applied part of the changes of 2adbba2 also for `verilog-indent-lists` set to t and it happened to also fix the `indent_genmod.v` test mentioned in #1163. Even though that issue shows as closed it seems this test was still broken, but it would be nice if it could be confirmed.

Thanks! 