### PR TITLE
Fix indentation after double comment.

### DIFF
--- a/tests/indent_comments_bug1717.v
+++ b/tests/indent_comments_bug1717.v
@@ -1,0 +1,16 @@
+// Bug 1717
+module test
+  (input wire test5 // bla
+   /*AUTOARG*/);
+
+`include "bla.vh"
+
+   reg        test4;
+
+   wire       test3;
+
+   //  // FIXXME
+              wire       test1 = test2; // wrong indent
+   wire                  test = test;
+
+endmodule

--- a/tests_ok/autoarg_comment.v
+++ b/tests_ok/autoarg_comment.v
@@ -10,7 +10,7 @@ module autoarg_comment
    );
    
    //verilint 332 OFF   //* Not all possible cases covered, but default case exists
-  
+   
    input  (* ATTRIB="val" *) income;
    output outgo2;
    

--- a/tests_ok/autoinst_bits_lba_gi.v
+++ b/tests_ok/autoinst_bits_lba_gi.v
@@ -60,7 +60,7 @@ module autoinst_bits_lba_gi
    );
    
    /////////////////////////////////////////////////////////////////////
-  // inputs
+   // inputs
    
    input         CLK;       // LBA clk
    

--- a/tests_ok/indent_comments_bug1717.v
+++ b/tests_ok/indent_comments_bug1717.v
@@ -1,0 +1,16 @@
+// Bug 1717
+module test
+  (input wire test5 // bla
+   /*AUTOARG*/);
+   
+`include "bla.vh"
+   
+   reg  test4;
+   
+   wire test3;
+   
+   //  // FIXXME
+   wire test1 = test2; // wrong indent
+   wire test  = test;
+   
+endmodule

--- a/tests_ok/verilint_113.v
+++ b/tests_ok/verilint_113.v
@@ -9,7 +9,7 @@ module cdl_io (/*AUTOARG*/
    output topsig;
    
    //Verilint 113 off // WARNING: in macro RSV_CDLBASE_RDWR, Multiple drivers to a flipflop
-          
+   
    reg    topsig;
 `define TOPSIG  {topsig}
    

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -6498,10 +6498,10 @@ Optional BOUND limits search."
 	    (let ((state (save-excursion (verilog-syntax-ppss))))
 	      (cond
                ((nth 7 state)  ; in // comment
-		(verilog-re-search-backward "//" nil 'move)
+		(re-search-backward "//" nil 'move)
                 (skip-chars-backward "/"))
                ((nth 4 state)  ; in /* */ comment
-		(verilog-re-search-backward "/\\*" nil 'move))))
+		(re-search-backward "/\\*" nil 'move))))
 	    (narrow-to-region bound (point))
 	    (while (/= here (point))
 	      (setq here (point))


### PR DESCRIPTION
Hi,

This PR fixes indentation of next line when there are comment delimiters inside a comment.

Related issue: #1717   
