### PR TITLE
Fix fontifying of variable names and overriding of keywords.

### DIFF
--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -3396,7 +3396,7 @@ See also `verilog-font-lock-extra-types'.")
                         (verilog-single-declaration-end verilog-highlight-max-lookahead)
                       (point)) ;; => current declaration statement is of 0 length
                    nil ;; Post-form: nothing to be done
-                   '(0 font-lock-variable-name-face t t)))
+                   '(0 font-lock-variable-name-face nil t)))
                 )))
 
 
@@ -3714,7 +3714,7 @@ obtained using `verilog-single-declaration-end'."
         (verilog-forward-ws&directives limit)
         (setq old-point nil)
         (while (and (< (point) limit)
-                    (not (member (char-after) '(?, ?\) ?\;)))
+                    (not (member (char-after) '(?, ?\) ?\] ?\} ?\;)))
                     (not (eq old-point (point))))
           (setq old-point (point))
           (verilog-forward-ws&directives limit)


### PR DESCRIPTION
Hi,

This PR partially fixes issue #1752.

The changes in the updated regexp that @kaushalmodi proposed to detect signed/unsigned declarations were included after refactoring in 72c2b1f. However after this commit there was a bug in `verilog-declaration-varname-matcher` when trying to execute `forward-sexp` over a closing brace/bracket/parenthesis.

The PR also avoids fontify overriding of reserved keywords on variable declarations.

It still fontifies wrongly typedef enum declarations since these need some additional debugging (possibly in future PRs).

Thanks!