### PR TITLE
Add precedence to paren expressions for sexp funcs navigation.

### DIFF
--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -3757,9 +3757,14 @@ Use filename, if current buffer being edited shorten to just buffer name."
 	(elsec 1)
 	(found nil)
 	(st (point)))
-    (if (not (looking-at "\\<"))
-	(forward-word-strictly -1))
+    (unless (looking-at "\\<")
+      (forward-word-strictly -1))
     (cond
+     ((save-excursion
+        (goto-char st)
+        (member (preceding-char) '(?\) ?\} ?\])))
+      (goto-char st)
+      (backward-sexp 1))
      ((verilog-skip-backward-comment-or-string))
      ((looking-at "\\<else\\>")
       (setq reg (concat
@@ -3825,9 +3830,14 @@ Use filename, if current buffer being edited shorten to just buffer name."
 	(md 2)
 	(st (point))
 	(nest 'yes))
-    (if (not (looking-at "\\<"))
-	(forward-word-strictly -1))
+    (unless (looking-at "\\<")
+      (forward-word-strictly -1))
     (cond
+     ((save-excursion
+        (goto-char st)
+        (member (following-char) '(?\( ?\{ ?\[)))
+      (goto-char st)
+      (forward-sexp 1))
      ((verilog-skip-forward-comment-or-string)
       (verilog-forward-syntactic-ws))
      ((looking-at verilog-beg-block-re-ordered)


### PR DESCRIPTION
Hi,

This PR fixes a bug when using `verilog-backward-sexp`. Considering the following snippet:
```verilog
    constraint addr_range {
        (atype == low ) -> addr inside { [0 : 15] };  //  line 1 comment
        (atype == mid ) -> addr inside { [16 : 127]}; //  line 2 comment
        (atype == high) -> addr inside {[128 : 255]}; //  line 3 comment
    }
```
If point is after `}` and `verilog-backward-sexp` is executed, the cursor will move to the beginning of line 3 comment instead of to its corresponding opening brace. With this fix parenthetical expressions have higher precedence in `verilog-backward-sexp` cond block and it works as expected.

Thanks!
