### PR TITLE
Fix alignment of structs and enums.

### DIFF
--- a/tests/autoreset_latch.v
+++ b/tests/autoreset_latch.v
@@ -5,7 +5,7 @@ module device(
 	      output logic 	 pass, fail
 	      input [7:0] 	 D, in0,in1 );
 
-   enum 			 logic [2:0] {IDLE, START, RUN, PASS, FAIL } state, next_state;
+   enum logic [2:0] {IDLE, START, RUN, PASS, FAIL } state, next_state;
    logic 			 ready, next_ready;
    logic 			 next_pass, next_fail;
 

--- a/tests/indent_enum.v
+++ b/tests/indent_enum.v
@@ -1,10 +1,14 @@
+module indent_enum;
+
 enum int unsigned {
-    STATE_0 = 0,
-    STATE_2 = 2
+STATE_0 = 0,
+STATE_2 = 2
 } state;
 
 enum int unsigned {
-    STATE_0 = 0,
-    STATE_1,
-    STATE_2
-    } state, next;
+STATE_0 = 0,
+STATE_1,
+STATE_2
+} state, next;
+
+endmodule

--- a/tests/indent_list_nil_typedef_enum.sv
+++ b/tests/indent_list_nil_typedef_enum.sv
@@ -1,0 +1,111 @@
+module typedef_enum_indent;
+
+logic variable1;
+logic signed [1:0] variable2;
+logic variable3;
+logic signed [1:0] variable4;
+
+typedef enum logic [1:0] {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum logic [1:0] {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0] {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0] {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum logic [1:0]
+{STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0]
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0]
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+}
+enum_t;
+
+typedef enum {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum
+{STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+}
+enum_t;
+
+
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:
+

--- a/tests/indent_struct.v
+++ b/tests/indent_struct.v
@@ -1,45 +1,45 @@
 module foo;
-   
-   a = { g + c; };
-   a = c;
-   
-   typedef struct {
-      reg 	  r;
-      ahb_op_t         op;             // Read, write, etc.
-      ahb_cycle_type_t cti;            // Cycle type for bursts
-      ahb_incr_type_t  incr;           // Increment type (for bursts)
-      bit 	  b;
-      reg 	  r;
-      ahb_thingy a;
-      bit [31:2]  addr;           // Starting address
-      bit [3:0]   byte_sel;       // Byte lane select
-      int 	  len;            // Length of transfer
-      bit [31:0]  data[0:7];      // Write data
-   } ahb_req_t;
-   
-   struct 	  {
-      reg 	  f;
-      xyzzy b;
-   };
-   struct 	  packed {
-      int 	  a;  // ok
-   };
-   struct 	  packed signed {
-      int 	  a;  // woops
-   };
-   struct 	  packed unsigned {
-      int 	  a;  // woops
-   };
-   
+
+a = { g + c; };
+a = c;
+
+typedef struct {
+reg r;
+ahb_op_t op; // Read, write, etc.
+ahb_cycle_type_t cti; // Cycle type for bursts
+ahb_incr_type_t incr; // Increment type (for bursts)
+bit b;
+reg r;
+ahb_thingy a;
+bit [31:2] addr; // Starting address
+bit [3:0] byte_sel; // Byte lane select
+int len; // Length of transfer
+bit [31:0] data[0:7]; // Write data
+} ahb_req_t;
+
+struct {
+reg f;
+xyzzy b;
+};
+struct packed {
+int a; // ok
+};
+struct packed signed {
+int a; // woops
+};
+struct packed unsigned {
+int a; // woops
+};
+
 endmodule // foo
 
 module foo (
-    input a;
-    input c;
-    output d;
-	    );
-   always @(a) g;
-   
-   
+input a;
+input c;
+output d;
+);
+always @(a) g;
+
+
 
 endmodule // foo

--- a/tests/indent_typedef_enum.sv
+++ b/tests/indent_typedef_enum.sv
@@ -1,0 +1,106 @@
+module typedef_enum_indent;
+
+logic variable1;
+logic signed [1:0] variable2;
+logic variable3;
+logic signed [1:0] variable4;
+
+typedef enum logic [1:0] {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum logic [1:0] {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0] {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0] {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum logic [1:0]
+{STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0]
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum logic [1:0]
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+}
+enum_t;
+
+typedef enum {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum {STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum {
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3} enum_t;
+
+typedef enum
+{STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+} enum_t;
+
+typedef enum
+{
+STATE_0,
+STATE_1,
+STATE_2,
+STATE_3
+}
+enum_t;
+
+
+endmodule
+

--- a/tests_ok/autoreset_latch.v
+++ b/tests_ok/autoreset_latch.v
@@ -5,7 +5,7 @@ module device(
               output logic       pass, fail
               input [7:0]        D, in0,in1 );
    
-   enum  logic [2:0] {IDLE, START, RUN, PASS, FAIL } state, next_state;
+   enum logic [2:0] {IDLE, START, RUN, PASS, FAIL } state, next_state;
    logic ready, next_ready;
    logic next_pass, next_fail;
    

--- a/tests_ok/autowire_pkg_bug195.v
+++ b/tests_ok/autowire_pkg_bug195.v
@@ -6,7 +6,7 @@ package testcase_pkg;
    
    localparam           uint SIZE = 8;
    
-   typedef enum         {ENUM1, ENUM2} enum_t;
+   typedef enum {ENUM1, ENUM2} enum_t;
    
 endpackage
 

--- a/tests_ok/indent_enum.v
+++ b/tests_ok/indent_enum.v
@@ -1,10 +1,14 @@
-enum int unsigned {
-   STATE_0 = 0,
-   STATE_2 = 2
-} state;
-
-enum int unsigned {
-   STATE_0 = 0,
-   STATE_1,
-   STATE_2
-} state, next;
+module indent_enum;
+   
+   enum int unsigned {
+      STATE_0 = 0,
+      STATE_2 = 2
+   } state;
+   
+   enum int unsigned {
+      STATE_0 = 0,
+      STATE_1,
+      STATE_2
+   } state, next;
+   
+endmodule

--- a/tests_ok/indent_list_nil_typedef_enum.sv
+++ b/tests_ok/indent_list_nil_typedef_enum.sv
@@ -1,0 +1,111 @@
+module typedef_enum_indent;
+   
+   logic              variable1;
+   logic signed [1:0] variable2;
+   logic              variable3;
+   logic signed [1:0] variable4;
+   
+   typedef enum logic [1:0] {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3} enum_t;
+   
+   typedef enum logic [1:0] {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum logic [1:0] {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum logic [1:0] {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3} enum_t;
+   
+   typedef enum logic [1:0]
+     {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum logic [1:0]
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum logic [1:0]
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      }
+       enum_t;
+   
+   typedef enum {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3} enum_t;
+   
+   typedef enum {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3} enum_t;
+   
+   typedef enum 
+     {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum 
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum 
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      }
+       enum_t;
+   
+   
+endmodule
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:
+

--- a/tests_ok/indent_modeln.v
+++ b/tests_ok/indent_modeln.v
@@ -6,12 +6,12 @@ class i_sb_c extends base_sb_c;
    `uvm_register_cb(i_sb_c, sb_i_cb_c)
    
    //------------
-   int            drain_time_ns = 5000;
+   int drain_time_ns = 5000;
    
    //------------
    
    typedef struct {
-      pem_intf_defs::pem_ncb_err_rsp_t err_rsp;
+      pem_intf_defs::pem_ncb_err_rsp_t  err_rsp;
       int rcv_time;
    } ncbi_err_rsp_t;
    

--- a/tests_ok/indent_typedef_enum.sv
+++ b/tests_ok/indent_typedef_enum.sv
@@ -1,0 +1,106 @@
+module typedef_enum_indent;
+   
+   logic              variable1;
+   logic signed [1:0] variable2;
+   logic              variable3;
+   logic signed [1:0] variable4;
+   
+   typedef enum logic [1:0] {STATE_0,
+                             STATE_1,
+                             STATE_2,
+                             STATE_3} enum_t;
+   
+   typedef enum logic [1:0] {STATE_0,
+                             STATE_1,
+                             STATE_2,
+                             STATE_3
+                             } enum_t;
+   
+   typedef enum logic [1:0] {
+                             STATE_0,
+                             STATE_1,
+                             STATE_2,
+                             STATE_3
+                             } enum_t;
+   
+   typedef enum logic [1:0] {
+                             STATE_0,
+                             STATE_1,
+                             STATE_2,
+                             STATE_3} enum_t;
+   
+   typedef enum logic [1:0]
+     {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum logic [1:0]
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum logic [1:0]
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      }
+       enum_t;
+   
+   typedef enum {STATE_0,
+                 STATE_1,
+                 STATE_2,
+                 STATE_3} enum_t;
+   
+   typedef enum {STATE_0,
+                 STATE_1,
+                 STATE_2,
+                 STATE_3
+                 } enum_t;
+   
+   typedef enum {
+                 STATE_0,
+                 STATE_1,
+                 STATE_2,
+                 STATE_3
+                 } enum_t;
+   
+   typedef enum {
+                 STATE_0,
+                 STATE_1,
+                 STATE_2,
+                 STATE_3} enum_t;
+   
+   typedef enum 
+     {STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum 
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      } enum_t;
+   
+   typedef enum 
+     {
+      STATE_0,
+      STATE_1,
+      STATE_2,
+      STATE_3
+      }
+       enum_t;
+   
+   
+endmodule
+

--- a/tests_ok/v2k_typedef_yee_inc.v
+++ b/tests_ok/v2k_typedef_yee_inc.v
@@ -10,8 +10,8 @@ typedef bit logic_t; // Use two-state logic
 typedef logic logic_t; // Use four-state logic
  `endif
 
-typedef reg   ff_t;  // Default F/F type
-typedef reg   lat_t; // Default latch type
+typedef reg ff_t;  // Default F/F type
+typedef reg lat_t; // Default latch type
 
 //----------------------------
 // 24 bit wide pixel types


### PR DESCRIPTION
Hi,

This PR fixes the alignment of (typedef) enums and structs declarations. Since these were being detected wrongly, the new changes just ignore them when running `verilog-pretty-declarations`. However, fields inside a struct still get aligned properly.

For example, considering the following example from #1752 discussion:
```verilog
module pr_example;

logic correct_0;
logic signed [1:0] incorrect_0;
logic correct_1;
logic signed [1:0] incorrect_1;

typedef enum logic [1:0]
{STATE_0,
STATE_1,
STATE_2,
STATE_3} t_incorrect_2;
t_incorrect_2 incorrect_3;

endmodule
```

After indenting and executing `verilog-pretty-declarations` this is the result before the PR:
```verilog
module pr_example;
    
    logic              correct_0;
    logic signed [1:0] incorrect_0;
    logic              correct_1;
    logic signed [1:0] incorrect_1;

    typedef enum       logic [1:0]
                       {STATE_0,
                       STATE_1,
                       STATE_2,
                       STATE_3} t_incorrect_2;
    t_incorrect_2 incorrect_3;
    
endmodule // pr_example
```

And this is the result after these changes:
```verilog
module pr_example;
    
    logic              correct_0;
    logic signed [1:0] incorrect_0;
    logic              correct_1;
    logic signed [1:0] incorrect_1;

    typedef enum logic [1:0]
        {STATE_0,
        STATE_1,
        STATE_2,
        STATE_3} t_incorrect_2;
    t_incorrect_2 incorrect_3;
    
endmodule // pr_example
```

Regarding typedef structs, considering the already indented piece of code:
```verilog
module pr_example;

    typedef struct packed {
        int field1;
        int unsigned field2;
        logic [7:0] field3;
    } my_type_t;

endmodule
```

This is the result before running `verilog-pretty-declarations` at typedef struct line before PR changes:
```verilog
module pr_example;

    typedef struct packed {
    int            field1;
    int unsigned   field2;
    logic [7:0]    field3;
    } my_type_t;

endmodule
```

After these changes, there would be no effect if running `verilog-pretty-declarations` at typedef struct line. However, if running it over one of the field's lines they get properly aligned inside the struct:
```verilog
module pr_example;

    typedef struct packed {
        int          field1;
        int unsigned field2;
        logic [7:0]  field3;
    } my_type_t;

endmodule
```

I also added a couple of tests. One of them still needs some indentation fixes (with `verilog-indent-lists` set to t), but that will come in a different PR.

Thanks!