### PR TITLE
Fix indentation of assignments and enums with indent-lists nil

### DIFF
--- a/tests/indent_list_nil_continued_line.sv
+++ b/tests/indent_list_nil_continued_line.sv
@@ -1,0 +1,39 @@
+module x;
+initial begin
+startc_c <= (valid && (state == THE_START));
+end_c <= (valid && (state == THE_END));
+valid_c <= (valid &&
+(state != IDLE) &&
+(state != SKIP_DATA));
+end // initial begin
+endmodule : x
+
+
+module x;
+initial begin
+startc_c <= (valid && (state == THE_START));
+end_c <= (
+valid,
+(state == THE_END)
+);
+valid_c <= { valid ,
+(state != IDLE) ,
+(state != SKIP_DATA)
+};
+end // initial begin
+endmodule : x
+
+
+module x;
+
+initial begin
+variable[i].value[0] = {signal3, signal2,
+signal1, signal0};
+end
+
+endmodule: x
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_continued_line.sv
+++ b/tests_ok/indent_list_nil_continued_line.sv
@@ -1,0 +1,39 @@
+module x;
+   initial begin
+      startc_c           <= (valid && (state == THE_START));
+      end_c              <= (valid && (state == THE_END));
+      valid_c            <= (valid &&
+                  (state != IDLE) &&
+                  (state != SKIP_DATA));
+   end // initial begin
+endmodule : x
+
+
+module x;
+   initial begin
+      startc_c <= (valid && (state == THE_START));
+      end_c    <= (
+                   valid,
+                   (state == THE_END)
+                   );
+      valid_c             <= { valid ,
+                   (state != IDLE) ,
+                   (state != SKIP_DATA)
+                               };
+   end // initial begin
+endmodule : x
+
+
+module x;
+   
+   initial begin
+      variable[i].value[0] = {signal3, signal2,
+                              signal1, signal0};
+   end
+   
+endmodule: x
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/indent_list_nil_typedef_enum.sv
+++ b/tests_ok/indent_list_nil_typedef_enum.sv
@@ -6,22 +6,22 @@ module typedef_enum_indent;
    logic signed [1:0] variable4;
    
    typedef enum logic [1:0] {STATE_0,
-      STATE_1,
-      STATE_2,
-      STATE_3} enum_t;
+                             STATE_1,
+                             STATE_2,
+                             STATE_3} enum_t;
    
    typedef enum logic [1:0] {STATE_0,
-      STATE_1,
-      STATE_2,
-      STATE_3
-      } enum_t;
+                             STATE_1,
+                             STATE_2,
+                             STATE_3
+   } enum_t;
    
    typedef enum logic [1:0] {
       STATE_0,
       STATE_1,
       STATE_2,
       STATE_3
-      } enum_t;
+   } enum_t;
    
    typedef enum logic [1:0] {
       STATE_0,
@@ -34,7 +34,7 @@ module typedef_enum_indent;
       STATE_1,
       STATE_2,
       STATE_3
-      } enum_t;
+   } enum_t;
    
    typedef enum logic [1:0]
      {
@@ -42,7 +42,7 @@ module typedef_enum_indent;
       STATE_1,
       STATE_2,
       STATE_3
-      } enum_t;
+   } enum_t;
    
    typedef enum logic [1:0]
      {
@@ -50,26 +50,26 @@ module typedef_enum_indent;
       STATE_1,
       STATE_2,
       STATE_3
-      }
+   }
        enum_t;
    
    typedef enum {STATE_0,
-      STATE_1,
-      STATE_2,
-      STATE_3} enum_t;
+                 STATE_1,
+                 STATE_2,
+                 STATE_3} enum_t;
    
    typedef enum {STATE_0,
-      STATE_1,
-      STATE_2,
-      STATE_3
-      } enum_t;
+                 STATE_1,
+                 STATE_2,
+                 STATE_3
+   } enum_t;
    
    typedef enum {
       STATE_0,
       STATE_1,
       STATE_2,
       STATE_3
-      } enum_t;
+   } enum_t;
    
    typedef enum {
       STATE_0,
@@ -82,7 +82,7 @@ module typedef_enum_indent;
       STATE_1,
       STATE_2,
       STATE_3
-      } enum_t;
+   } enum_t;
    
    typedef enum 
      {
@@ -90,7 +90,7 @@ module typedef_enum_indent;
       STATE_1,
       STATE_2,
       STATE_3
-      } enum_t;
+   } enum_t;
    
    typedef enum 
      {
@@ -98,7 +98,7 @@ module typedef_enum_indent;
       STATE_1,
       STATE_2,
       STATE_3
-      }
+   }
        enum_t;
    
    


### PR DESCRIPTION
Hi,

The following PR fixes indentation of enums and continued lines of assignments when `verilog-indent-lists` is set to nil.

These snippets from `tests_ok/indent_list_nil_continued_line.sv` are indented correctly but do not get aligned properly after running `verilog-pretty-expr`. This is an already existing issue that will be fixed in another PR:
```verilog
      startc_c           <= (valid && (state == THE_START));
      end_c              <= (valid && (state == THE_END));
      valid_c            <= (valid &&
                  (state != IDLE) &&
                  (state != SKIP_DATA));
```

```verilog
      valid_c             <= { valid ,
                   (state != IDLE) ,
                   (state != SKIP_DATA)
                               };
```

These are the results after indenting without `verilog-pretty-expr`:
```verilog
        startc_c           <= (valid && (state == THE_START));
        end_c              <= (valid && (state == THE_END));
        valid_c            <= (valid &&
                               (state != IDLE) &&
                               (state != SKIP_DATA));
```

```verilog
        valid_c             <= { valid ,
                                 (state != IDLE) ,
                                 (state != SKIP_DATA)
                                 };
```

Thanks!