### PR TITLE
Prevent verilog-pretty-expr from executing on multiline assignments

### DIFF
--- a/tests/sol_asense.v
+++ b/tests/sol_asense.v
@@ -67,7 +67,7 @@ module x (/*AUTOARG*/
       {MBOOTH_P[i*4+3],
        MBOOTH_P[i*4+2],
        MBOOTH_P[i*4+1],
-       MBOOTH_P[i*4+0]}     = MTEMP2[3:0];
+       MBOOTH_P[i*4+0]} = MTEMP2[3:0];
 
    end
 

--- a/tests_ok/autoreset_cond.v
+++ b/tests_ok/autoreset_cond.v
@@ -9,11 +9,11 @@ module x;
          // End of automatics
       end
       else begin
-         foo                <= idx_adr_1a[1:0];
-         bar                <= (idx_sel_2a == 2'h0 ? idx_rd_dat0_2a[12:0] :
+         foo <= idx_adr_1a[1:0];
+         bar <= (idx_sel_2a == 2'h0 ? idx_rd_dat0_2a[12:0] :
                  idx_sel_2a == 2'h1 ? idx_rd_dat1_2a[12:0] :
                  idx_sel_2a == 2'h2 ? idx_rd_dat2_2a[12:0] :
-                                /**/                 idx_rd_dat3_2a[12:0]);
+                 /**/                 idx_rd_dat3_2a[12:0]);
       end
    end
    

--- a/tests_ok/autoreset_equal_extra.v
+++ b/tests_ok/autoreset_equal_extra.v
@@ -12,10 +12,10 @@ module autoreset_equal_extra ();
       end
       else begin
          if (fifo.sot) begin
-            csi.src                               <= fifo.src;
-            csi.wr                                <= (fifo.data.cb_req.req.cmd == ncb_defs::NCBO_RSVD_LMTST
-                       | fifo.data.cb_req.req.cmd == ncb_defs::NCBO_IOBST
-                                                      );
+            csi.src <= fifo.src;
+            csi.wr  <= (fifo.data.cb_req.req.cmd == ncb_defs::NCBO_RSVD_LMTST
+                        | fifo.data.cb_req.req.cmd == ncb_defs::NCBO_IOBST
+                        );
             csi.cmd <= fifo.data.cb_req.req.cmd;
          end
       end

--- a/tests_ok/indent_list_nil_continued_line.sv
+++ b/tests_ok/indent_list_nil_continued_line.sv
@@ -1,10 +1,10 @@
 module x;
    initial begin
-      startc_c           <= (valid && (state == THE_START));
-      end_c              <= (valid && (state == THE_END));
-      valid_c            <= (valid &&
-                  (state != IDLE) &&
-                  (state != SKIP_DATA));
+      startc_c <= (valid && (state == THE_START));
+      end_c    <= (valid && (state == THE_END));
+      valid_c  <= (valid &&
+                   (state != IDLE) &&
+                   (state != SKIP_DATA));
    end // initial begin
 endmodule : x
 
@@ -16,10 +16,10 @@ module x;
                    valid,
                    (state == THE_END)
                    );
-      valid_c             <= { valid ,
+      valid_c <= { valid ,
                    (state != IDLE) ,
                    (state != SKIP_DATA)
-                               };
+                   };
    end // initial begin
 endmodule : x
 

--- a/tests_ok/testcases.v
+++ b/tests_ok/testcases.v
@@ -125,7 +125,7 @@ module testmodule (/*AUTOARG*/
      begin: label_no_sense
         casex (outw1) // synopsys full_case parallel_case
           {`shift_instr,3'bxxx}:
-            outb3            = in3[0];
+            outb3 = in3[0];
           8'b00001x10: outb3 = in4[0];
           8'b00110011:
             if (in5[0])


### PR DESCRIPTION
Hi,

This PR prevents the function `verilog-pretty-expr` from executing on multiline assignments. 

In the example from previous PR #1790 the following snippet was wrongly aligned due to the presence of `!=` in the multiline assignment:
```verilog
      startc_c           <= (valid && (state == THE_START));
      end_c              <= (valid && (state == THE_END));
      valid_c            <= (valid &&
                  (state != IDLE) &&
                  (state != SKIP_DATA));
```
After the PR:
```verilog
      startc_c <= (valid && (state == THE_START));
      end_c    <= (valid && (state == THE_END));
      valid_c  <= (valid &&
                   (state != IDLE) &&
                   (state != SKIP_DATA));
```

Thanks!