### PR TITLE
Fix bug in boundaries of verilog-pretty-expr.

### DIFF
--- a/tests_ok/indent_unique_case-1.v
+++ b/tests_ok/indent_unique_case-1.v
@@ -149,7 +149,7 @@ module  xxx_xxxxxx  (input wire clk, input wire reset);
            
            
            BB_CMLLL : begin
-              lll_start     <= 1'b1;
+              lll_start <= 1'b1;
               
               if (jjjj_left <= 4) begin
                  lll_wcnt <= jjjj_left[2:0];
@@ -220,8 +220,8 @@ module  xxx_xxxxxx  (input wire clk, input wire reset);
               end
               else begin
                  
-                 rd_rrrr            <= rd_rrrr + ttttt_cur;
-                 lll_rrrr           <= lll_rrrr + oooo_cur;
+                 rd_rrrr  <= rd_rrrr + ttttt_cur;
+                 lll_rrrr <= lll_rrrr + oooo_cur;
                  
                  
                  if (jjjj_left_oooo <= oooo_cur) begin
@@ -250,7 +250,7 @@ module  xxx_xxxxxx  (input wire clk, input wire reset);
            
            
            DD_CMRD : begin
-              uuuuu         <= 1'b1;
+              uuuuu <= 1'b1;
               
               if (jjjj_left <= 4) begin
                  qwerty <= 1'b1;

--- a/tests_ok/inject_first.v
+++ b/tests_ok/inject_first.v
@@ -8,7 +8,7 @@ module ex_inject (i, o,/*AUTOARG*/
    
    // Ok:
    always @ (/*AS*/i or j)
-     o            = i | j;
+     o = i | j;
    // No change:
    always @ (j) o = i | j;
    always @ (j or i or p) o = i | j;


### PR DESCRIPTION
Hi,

This PR fixes a bug in `verilog-pretty-expr` that produced a wrong alignment of statements when there were comparison operators nearby. For example:
```verilog
           DD_CMRD : begin
              uuuuu         <= 1'b1;
              
              if (jjjj_left <= 4) begin
                 qwerty <= 1'b1;
              end
```

After the PR:
```verilog
           DD_CMRD : begin
              uuuuu <= 1'b1;
              
              if (jjjj_left <= 4) begin
                 qwerty <= 1'b1;
              end
```

This PR will also help simplifying implementing a feature that will allow aligning expressions of continuous assignments.

Thanks!
