### PR TITLE
Add support to align expressions of continuous assignments

### DIFF
--- a/tests/align_assign_expr.sv
+++ b/tests/align_assign_expr.sv
@@ -1,0 +1,44 @@
+module align_assign_expr (
+input logic clk,
+input logic rst_n,
+input logic [3:0] i,
+output logic o1,
+output logic [3:0] o2,
+output logic [3:0] o3
+);
+
+parameter WIDTH = 4;
+
+logic [WIDTH-1:0] temp1 = 4'h0;
+logic temp2 = 1'b0;
+logic signed temp3 = '0;
+
+always_ff @(posedge clk) begin : label
+if (!rst_n) begin
+o1 <= 1'b0;
+o2[1:0] <= 2'b00;
+o2[3] <= 1'b1;
+o2[4] <= 1'b0;
+o3 <= 4'h0;
+end
+else begin
+o1 <= 1'b1;
+o2[1:0] <= 2'b11;
+o2[3] <= 1'b0;
+o2[4] <= 1'b1;
+o3 <= 4'h1;
+end
+end : label
+
+assign o1 = &i;
+assign o2[1:0] = i[1:0];
+assign o2[WIDTH-1:2] = i[3:0];
+assign o3[0] = i;
+assign o3[1] = i;
+assign o3[3:2] = {i, i};
+
+endmodule : align_assign_expr
+
+// Local Variables:
+// verilog-align-assign-expr: t
+// End:

--- a/tests_ok/align_assign_expr.sv
+++ b/tests_ok/align_assign_expr.sv
@@ -1,0 +1,44 @@
+module align_assign_expr (
+                          input logic        clk,
+                          input logic        rst_n,
+                          input logic [3:0]  i,
+                          output logic       o1,
+                          output logic [3:0] o2,
+                          output logic [3:0] o3
+                          );
+   
+   parameter         WIDTH = 4;
+   
+   logic [WIDTH-1:0] temp1 = 4'h0;
+   logic             temp2 = 1'b0;
+   logic signed      temp3 = '0;
+   
+   always_ff @(posedge clk) begin : label
+      if (!rst_n) begin
+         o1      <= 1'b0;
+         o2[1:0] <= 2'b00;
+         o2[3]   <= 1'b1;
+         o2[4]   <= 1'b0;
+         o3      <= 4'h0;
+      end
+      else begin
+         o1      <= 1'b1;
+         o2[1:0] <= 2'b11;
+         o2[3]   <= 1'b0;
+         o2[4]   <= 1'b1;
+         o3      <= 4'h1;
+      end
+   end : label
+   
+   assign o1            = &i;
+   assign o2[1:0]       = i[1:0];
+   assign o2[WIDTH-1:2] = i[3:0];
+   assign o3[0]         = i;
+   assign o3[1]         = i;
+   assign o3[3:2]       = {i, i};
+   
+endmodule : align_assign_expr
+
+// Local Variables:
+// verilog-align-assign-expr: t
+// End:

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -762,6 +762,12 @@ Only works if `verilog-align-declaration-comments' is non-nil."
   :type 'integer)
 (put 'verilog-align-comment-distance 'safe-local-variable #'integerp)
 
+(defcustom verilog-align-assign-expr nil
+  "Non-nil means align expressions of continuous assignments."
+  :group 'verilog-mode-indent
+  :type 'boolean)
+(put 'verilog-align-assign-expr 'safe-local-variable #'verilog-booleanp)
+
 (defcustom verilog-minimum-comment-distance 10
   "Minimum distance (in lines) between begin and end required before a comment.
 Setting this variable to zero results in every end acquiring a comment; the
@@ -3049,6 +3055,18 @@ find the errors."
   (concat
    verilog-extended-complete-re "\\|\\(" verilog-basic-complete-no-default-re "\\)"))
 
+(defconst verilog-basic-complete-no-assign-re
+  (eval-when-compile
+    (verilog-regexp-words
+     '(
+       "always" "always_latch" "always_ff" "always_comb" "analog" "connectmodule" "constraint"
+       "import" "initial" "final" "module" "macromodule" "repeat" "randcase" "while"
+       "if" "for" "forever" "foreach" "else" "parameter" "do" "localparam" "assert"
+       ))))
+(defconst verilog-complete-no-assign-re
+  (concat
+   verilog-extended-complete-re "\\|\\(" verilog-basic-complete-no-assign-re "\\)"))
+
 (defconst verilog-end-statement-re
   (concat "\\(" verilog-beg-block-re "\\)\\|\\("
 	  verilog-end-block-re "\\)"))
@@ -4103,6 +4121,8 @@ Variables controlling indentation/edit style:
  `verilog-align-comment-distance' (default 1)
    Distance (in spaces) between longest declaration and comments.
    Only works if `verilog-align-declaration-comments' is non-nil.
+ `verilog-align-assign-expr'        (default nil)
+   Non-nil means align expressions of continuous assignments.
  `verilog-auto-lineup'              (default `declarations')
    List of contexts where auto lineup of code should be done.
 
@@ -7486,7 +7506,9 @@ If returned non-nil, update match data according to `verilog-assignment-operatio
   "Line up expressions around point.
 If QUIET is non-nil, do not print messages showing the progress of line-up."
   (interactive)
-  (let* ((discard-re verilog-complete-no-default-re)
+  (let* ((discard-re (if verilog-align-assign-expr
+                         verilog-complete-no-assign-re
+                       verilog-complete-no-default-re))
          (discard-re-line (concat "^\\s-*\\(" discard-re "\\)")))
     (unless (verilog-in-comment-or-string-p)
       (save-excursion
@@ -15232,6 +15254,7 @@ Files are checked based on `verilog-library-flags'."
      '(
        verilog-active-low-regexp
        verilog-after-save-font-hook
+       verilog-align-assign-expr
        verilog-align-comment-distance
        verilog-align-declaration-comments
        verilog-align-ifelse


### PR DESCRIPTION
Hi,

This PR adds support to align expressions of continuous assignments. This is configured by the use of a variable (`verilog-align-assign-expr`) that is enabled by default.

Considering the following snippet:
```verilog
   assign ExtraOut = 3'h0;
   assign SubOut = 3'h0;
   assign active_low_l = 4'h0;
   assign ignored_by_regexp = 4'h0;
```

Setting `verilog-align-assign-expr` to non-nil and running `verilog-pretty-expr` results in:
```verilog
   assign ExtraOut          = 3'h0;
   assign SubOut            = 3'h0;
   assign active_low_l      = 4'h0;
   assign ignored_by_regexp = 4'h0;
```

The PR also adds a test to ensure that disabling the feature keeps backwards compatibility (`tests/align_assign_expr_nil.sv`).

Cheers!