### PR TITLE
Improve indentation of defun parameters when indent-lists is nil

### DIFF
--- a/tests/indent_list_nil_param_port_list.sv
+++ b/tests/indent_list_nil_param_port_list.sv
@@ -1,0 +1,70 @@
+module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
+parameter integer PARAMETER_1 = 0,
+parameter integer PARAMETER_2 = 1,
+parameter integer PARAMETER_3 = 2,
+parameter integer PARAMETER_4 = 3,
+parameter integer PARAMETER_5 = 4,
+parameter integer PARAM_6 = 5,
+parameter integer PARAMETER7 = 6,
+parameter integer PARAM_LONGER = 7,
+parameter integer PARAM_EVEN_LONGER = 8,
+parameter integer PARAMETER_10 = 9,
+parameter integer PARAMETER_11 = 10,
+parameter integer PARAMETER_12 = 11,
+parameter integer PARAMETER_13 = 12)
+(
+input logic clk,
+input logic rst_n,
+input logic signal_1, // Random comment
+input logic [PARAMETER_0-1:0] signal2,
+input logic [PARAMETER_1-1:0] signal_longer_name,
+input logic signal3,
+output logic [PARAMETER_2-1:0] signal_other_name,
+input logic [PARAMETER_3-1:0] another_signal,
+output logic [PARAMETER_4-1:0] even_more_signals,
+output logic output_signal,
+output logic more_output_signals [PARAMETER_13],
+input logic packed_array [PARAMETER_5][PARAMETER_6], // Another random comment
+input logic [4:0][3:0] unpacked_array, // More comments
+input logic [4:0] unpacked_array_2 // Last comment
+);
+
+typedef struct packed{
+logic name1;
+logic [1:0] name2;
+logic name_3;
+logic name_4;
+} some_type_t;
+
+
+endmodule
+
+
+class parameterized_class #(
+type T1=int,
+type T2=int,
+type T3=int
+) extends base_class;
+
+T1 val;
+T2 val2;
+T3 val3;
+
+endclass
+
+
+class parameterized_class2 #(type T1=int,
+type T2=int,
+type T3=int) extends base_class;
+
+T1 val;
+T2 val2;
+T3 val3;
+
+endclass
+
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests/param_port_list.sv
+++ b/tests/param_port_list.sv
@@ -1,0 +1,65 @@
+module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
+parameter integer PARAMETER_1 = 0,
+parameter integer PARAMETER_2 = 1,
+parameter integer PARAMETER_3 = 2,
+parameter integer PARAMETER_4 = 3,
+parameter integer PARAMETER_5 = 4,
+parameter integer PARAM_6 = 5,
+parameter integer PARAMETER7 = 6,
+parameter integer PARAM_LONGER = 7,
+parameter integer PARAM_EVEN_LONGER = 8,
+parameter integer PARAMETER_10 = 9,
+parameter integer PARAMETER_11 = 10,
+parameter integer PARAMETER_12 = 11,
+parameter integer PARAMETER_13 = 12)
+(
+input logic clk,
+input logic rst_n,
+input logic signal_1, // Random comment
+input logic [PARAMETER_0-1:0] signal2,
+input logic [PARAMETER_1-1:0] signal_longer_name,
+input logic signal3,
+output logic [PARAMETER_2-1:0] signal_other_name,
+input logic [PARAMETER_3-1:0] another_signal,
+output logic [PARAMETER_4-1:0] even_more_signals,
+output logic output_signal,
+output logic more_output_signals [PARAMETER_13],
+input logic packed_array [PARAMETER_5][PARAMETER_6], // Another random comment
+input logic [4:0][3:0] unpacked_array, // More comments
+input logic [4:0] unpacked_array_2 // Last comment
+);
+
+typedef struct packed{
+logic name1;
+logic [1:0] name2;
+logic name_3;
+logic name_4;
+} some_type_t;
+
+
+endmodule
+
+
+class parameterized_class #(
+type T1=int,
+type T2=int,
+type T3=int
+) extends base_class;
+
+T1 val;
+T2 val2;
+T3 val3;
+
+endclass
+
+
+class parameterized_class2 #(type T1=int,
+type T2=int,
+type T3=int) extends base_class;
+
+T1 val;
+T2 val2;
+T3 val3;
+
+endclass
+

--- a/tests_ok/indent_list_nil_param_port_list.sv
+++ b/tests_ok/indent_list_nil_param_port_list.sv
@@ -1,0 +1,70 @@
+module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
+                          parameter integer PARAMETER_1 = 0,
+                          parameter integer PARAMETER_2 = 1,
+                          parameter integer PARAMETER_3 = 2,
+                          parameter integer PARAMETER_4 = 3,
+                          parameter integer PARAMETER_5 = 4,
+                          parameter integer PARAM_6 = 5,
+                          parameter integer PARAMETER7 = 6,
+                          parameter integer PARAM_LONGER = 7,
+                          parameter integer PARAM_EVEN_LONGER = 8,
+                          parameter integer PARAMETER_10 = 9,
+                          parameter integer PARAMETER_11 = 10,
+                          parameter integer PARAMETER_12 = 11,
+                          parameter integer PARAMETER_13 = 12)
+   (
+   input logic                    clk,
+   input logic                    rst_n,
+   input logic                    signal_1,                                // Random comment
+   input logic [PARAMETER_0-1:0]  signal2,
+   input logic [PARAMETER_1-1:0]  signal_longer_name,
+   input logic                    signal3,
+   output logic [PARAMETER_2-1:0] signal_other_name,
+   input logic [PARAMETER_3-1:0]  another_signal,
+   output logic [PARAMETER_4-1:0] even_more_signals,
+   output logic                   output_signal,
+   output logic                   more_output_signals [PARAMETER_13],
+   input logic                    packed_array [PARAMETER_5][PARAMETER_6], // Another random comment
+   input logic [4:0][3:0]         unpacked_array,                          // More comments
+   input logic [4:0]              unpacked_array_2                         // Last comment
+   );
+   
+   typedef struct packed{
+      logic       name1;
+      logic [1:0] name2;
+      logic       name_3;
+      logic       name_4;
+   } some_type_t;
+   
+   
+endmodule
+
+
+class parameterized_class #(
+   type T1=int,
+   type T2=int,
+   type T3=int
+) extends base_class;
+   
+   T1 val;
+   T2 val2;
+   T3 val3;
+   
+endclass
+
+
+class parameterized_class2 #(type T1=int,
+                             type T2=int,
+                             type T3=int) extends base_class;
+   
+   T1 val;
+   T2 val2;
+   T3 val3;
+   
+endclass
+
+
+
+// Local Variables:
+// verilog-indent-lists: nil
+// End:

--- a/tests_ok/param_port_list.sv
+++ b/tests_ok/param_port_list.sv
@@ -1,0 +1,65 @@
+module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
+                          parameter integer PARAMETER_1 = 0,
+                          parameter integer PARAMETER_2 = 1,
+                          parameter integer PARAMETER_3 = 2,
+                          parameter integer PARAMETER_4 = 3,
+                          parameter integer PARAMETER_5 = 4,
+                          parameter integer PARAM_6 = 5,
+                          parameter integer PARAMETER7 = 6,
+                          parameter integer PARAM_LONGER = 7,
+                          parameter integer PARAM_EVEN_LONGER = 8,
+                          parameter integer PARAMETER_10 = 9,
+                          parameter integer PARAMETER_11 = 10,
+                          parameter integer PARAMETER_12 = 11,
+                          parameter integer PARAMETER_13 = 12)
+   (
+    input logic                    clk,
+    input logic                    rst_n,
+    input logic                    signal_1,                                // Random comment
+    input logic [PARAMETER_0-1:0]  signal2,
+    input logic [PARAMETER_1-1:0]  signal_longer_name,
+    input logic                    signal3,
+    output logic [PARAMETER_2-1:0] signal_other_name,
+    input logic [PARAMETER_3-1:0]  another_signal,
+    output logic [PARAMETER_4-1:0] even_more_signals,
+    output logic                   output_signal,
+    output logic                   more_output_signals [PARAMETER_13],
+    input logic                    packed_array [PARAMETER_5][PARAMETER_6], // Another random comment
+    input logic [4:0][3:0]         unpacked_array,                          // More comments
+    input logic [4:0]              unpacked_array_2                         // Last comment
+    );
+   
+   typedef struct packed{
+      logic       name1;
+      logic [1:0] name2;
+      logic       name_3;
+      logic       name_4;
+   } some_type_t;
+   
+   
+endmodule
+
+
+class parameterized_class #(
+                            type T1=int,
+                            type T2=int,
+                            type T3=int
+                            ) extends base_class;
+   
+   T1 val;
+   T2 val2;
+   T3 val3;
+   
+endclass
+
+
+class parameterized_class2 #(type T1=int,
+                             type T2=int,
+                             type T3=int) extends base_class;
+   
+   T1 val;
+   T2 val2;
+   T3 val3;
+   
+endclass
+

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -7223,7 +7223,8 @@ Do not count named blocks or case-statements."
 
 (defun verilog-cparenexp-indent-level ()
   "Return indent level for current line inside a parenthetical expression."
-  (let ((close-par (looking-at "[)}]"))
+  (let ((pos (point))
+        (close-par (looking-at "[)}]"))
         pos-arg-paren)
     (save-excursion
       (verilog-backward-up-list 1)
@@ -7248,12 +7249,15 @@ Do not count named blocks or case-statements."
                (forward-char 1)
                (skip-chars-forward " \t\f" (point-at-eol))
                (current-column))
-              (;; 3) Inside a function/task argument list
-               (looking-at "\\(\\<\\(virtual\\|protected\\|static\\)\\>\\s-+\\)?\\(\\<task\\>\\|\\<function\\>\\)")
+              (;; 3) Inside a module/defun param list or function/task argument list
+               (or (looking-at verilog-defun-level-re)
+                   (looking-at "\\(\\<\\(virtual\\|protected\\|static\\)\\>\\s-+\\)?\\(\\<task\\>\\|\\<function\\>\\)"))
                (setq pos-arg-paren (save-excursion
-                                     (when (and (verilog-re-search-forward "(" (point-at-eol) 'move)
-                                                (skip-chars-forward " \t")
-                                                (not (eolp)))
+                                     (goto-char pos)
+                                     (verilog-backward-up-list 1)
+                                     (forward-char)
+                                     (skip-chars-forward " \t")
+                                     (when (not (eolp))
                                        (current-column))))
                (or pos-arg-paren
                    ;; arg in next line after (
@@ -7273,7 +7277,7 @@ Do not count named blocks or case-statements."
                (if (> (verilog-pos-at-forward-syntactic-ws) (point-at-eol))
                    (+ (verilog-col-at-beg-of-statement) verilog-indent-level)
                  (verilog-col-at-forward-syntactic-ws)))
-              (t ;; 6) Default: module parameter/port list
+              (t ;; 6) Default
                (+ (current-column) verilog-indent-level)))))))
 
 (defun verilog-indent-comment ()


### PR DESCRIPTION
Hi,

This PR improves indentation of module/interfaces/program/classes parameter lists when the variable `verilog-indent-lists` is set to nil. 

If the first parameter is in the same line as the opening parenthesis indentation will keep this alignment for the rest of parameters, as if `verilog-indent-lists` was non-nil.

This was before the PR:
```verilog
class parameterized_class #(type T1=int,
    type T2=int,
    type T3=int) extends base_class;
```
This is the result after the PR:
```verilog
class parameterized_class #(type T1=int,
                            type T2=int,
                            type T3=int) extends base_class;
```

If the parameter is in the next line after the parenthesis previous behavior is maintained:
```verilog
class parameterized_class #(
    type T1=int,
    type T2=int,
    type T3=int) extends base_class;
```

Thanks!
 
