### PR TITLE
Fix bug in alignment of expressions

### DIFF
--- a/tests_ok/autosense_if_else.v
+++ b/tests_ok/autosense_if_else.v
@@ -2,12 +2,12 @@ module x;
    
    always @ (/*AS*/a or b or c)
      if (a) q = b;
-   else r = c;
+     else r = c;
    
    always @ (/*AS*/a or b or c or d or e)
      if (a) q = b;
-   else if (c) r = d;
+     else if (c) r = d;
    /* skip comments as usual */
-   else r = e;
+     else r = e;
    
 endmodule

--- a/tests_ok/autosense_venkataramanan_begin.v
+++ b/tests_ok/autosense_venkataramanan_begin.v
@@ -6,7 +6,7 @@ module autosense_venkataramanan_begin(/*AUTOARG*/);
    always @(/*AUTOSENSE*/b) // I didn't expect to get "i" in AUTOSENSE
      begin : label
         integer i, j;
-        for (i=0; i< = 3; i = i + 1)
+        for (i=0; i<= 3; i = i + 1)
           vec[i] = b;
      end
    

--- a/tests_ok/autotieoff_assign.v
+++ b/tests_ok/autotieoff_assign.v
@@ -10,10 +10,10 @@ module autotieoff_signed (/*AUTOARG*/
    
    /*AUTOTIEOFF*/
    // Beginning of automatic tieoffs (for this module's unterminated outputs)
-   assign ExtraOut = 3'h0;
-   assign SubOut = 3'h0;
-   assign active_low_l = 4'h0;
-   assign ignored_by_regexp = 4'h0;
+   assign ExtraOut                              = 3'h0;
+   assign SubOut                                = 3'h0;
+   assign active_low_l                          = 4'h0;
+   assign ignored_by_regexp                     = 4'h0;
    // End of automatics
    
 endmodule

--- a/tests_ok/autotieoff_inoutmod.v
+++ b/tests_ok/autotieoff_inoutmod.v
@@ -29,8 +29,8 @@ module my_module_stub
    
    /*AUTOTIEOFF*/
    // Beginning of automatic tieoffs (for this module's unterminated outputs)
-   assign a = 1'h0;
-   assign b = 1'h0;
+   assign a                                     = 1'h0;
+   assign b                                     = 1'h0;
    // End of automatics
    
 endmodule : my_module_stub

--- a/tests_ok/autowire_pkg_bug195.v
+++ b/tests_ok/autowire_pkg_bug195.v
@@ -24,7 +24,7 @@ module testcase_top
    logic [testcase_pkg::SIZE-1:0] sub_in;  // From testcase_sub1 of testcase_sub1.v
    logic [testcase_pkg::SIZE-1:0] sub_out; // From testcase_sub2 of testcase_sub2.v
    // End of automatics
-   assign top_out = sub_out;
+   assign top_out  = sub_out;
    testcase_sub1 testcase_sub1 (.*,
                                 // Outputs
                                 .sub_enum       (sub_enum),      // Implicit .*

--- a/tests_ok/autowire_req_sw.v
+++ b/tests_ok/autowire_req_sw.v
@@ -7,7 +7,7 @@ module autowire_req_sw
    /*AUTOINPUT*/
    );
    
-   assign Bnk0Req = Cpu0Req;
+   assign Bnk0Req =  Cpu0Req;
    
    
 endmodule

--- a/tests_ok/hangcase.v
+++ b/tests_ok/hangcase.v
@@ -3,57 +3,57 @@
 module hangcase (/*AUTOARG*/);
    
    //
-   assign w_rdat_ena = ({16{foo[ 0]}} & bar ) |
-                       ({16{foo[ 1]}} & bar ) |
-                       ({16{foo[ 2]}} & bar ) |
-                       ({16{foo[ 3]}} & bar ) |
-                       ({16{foo[ 4]}} & bar ) |
-                       ({16{foo[ 5]}} & bar ) |
-                       ({16{foo[ 6]}} & bar ) |
-                       ({16{foo[ 7]}} & bar ) |
-                       ({16{foo[ 8]}} & bar ) |
-                       ({16{foo[ 9]}} & bar ) |
-                       ({16{foo[10]}} & bar ) |
-                       ({16{foo[11]}} & bar ) |
-                       ({16{foo[12]}} & bar ) |
-                       ({16{foo[13]}} & bar ) |
-                       ({16{foo[14]}} & bar ) |
-                       ({16{foo[15]}} & bar ) ;
+   assign w_rdat_ena       = ({16{foo[ 0]}} & bar ) |
+                             ({16{foo[ 1]}} & bar ) |
+                             ({16{foo[ 2]}} & bar ) |
+                             ({16{foo[ 3]}} & bar ) |
+                             ({16{foo[ 4]}} & bar ) |
+                             ({16{foo[ 5]}} & bar ) |
+                             ({16{foo[ 6]}} & bar ) |
+                             ({16{foo[ 7]}} & bar ) |
+                             ({16{foo[ 8]}} & bar ) |
+                             ({16{foo[ 9]}} & bar ) |
+                             ({16{foo[10]}} & bar ) |
+                             ({16{foo[11]}} & bar ) |
+                             ({16{foo[12]}} & bar ) |
+                             ({16{foo[13]}} & bar ) |
+                             ({16{foo[14]}} & bar ) |
+                             ({16{foo[15]}} & bar ) ;
    
    //
-   assign w_rdat_mrk = ({16{foo[ 0]}} & bar & baz ) |
-                       ({16{foo[ 1]}} & bar & baz ) |
-                       ({16{foo[ 2]}} & bar & baz ) |
-                       ({16{foo[ 3]}} & bar & baz ) |
-                       ({16{foo[ 4]}} & bar & baz ) |
-                       ({16{foo[ 5]}} & bar & baz ) |
-                       ({16{foo[ 6]}} & bar & baz ) |
-                       ({16{foo[ 7]}} & bar & baz ) |
-                       ({16{foo[ 8]}} & bar & baz ) |
-                       ({16{foo[ 9]}} & bar & baz ) |
-                       ({16{foo[10]}} & bar & baz ) |
-                       ({16{foo[11]}} & bar & baz ) |
-                       ({16{foo[12]}} & bar & baz ) |
-                       ({16{foo[13]}} & bar & baz ) |
-                       ({16{foo[14]}} & bar & baz ) |
-                       ({16{foo[15]}} & bar & baz ) ;
+   assign w_rdat_mrk       = ({16{foo[ 0]}} & bar & baz ) |
+                             ({16{foo[ 1]}} & bar & baz ) |
+                             ({16{foo[ 2]}} & bar & baz ) |
+                             ({16{foo[ 3]}} & bar & baz ) |
+                             ({16{foo[ 4]}} & bar & baz ) |
+                             ({16{foo[ 5]}} & bar & baz ) |
+                             ({16{foo[ 6]}} & bar & baz ) |
+                             ({16{foo[ 7]}} & bar & baz ) |
+                             ({16{foo[ 8]}} & bar & baz ) |
+                             ({16{foo[ 9]}} & bar & baz ) |
+                             ({16{foo[10]}} & bar & baz ) |
+                             ({16{foo[11]}} & bar & baz ) |
+                             ({16{foo[12]}} & bar & baz ) |
+                             ({16{foo[13]}} & bar & baz ) |
+                             ({16{foo[14]}} & bar & baz ) |
+                             ({16{foo[15]}} & bar & baz ) ;
    
    //
-   assign w_wdat_ena_set = ({16{ena_set}} & col_dec    );
-   assign w_wdat_ena_clr = ({16{ena_clr}} & col_dec    );
-   assign w_wdat_mrk_set = ({16{mrk_set}} & w_rdat_ena );
-   assign w_wdat_mrk_clr = ({16{mrk_clr}} & col_dec    );
-   assign w_wdat_ena = (w_rdat_ena & ~w_wdat_ena_clr) | w_wdat_ena_set;
-   assign w_wdat_mrk = (w_rdat_mrk & ~w_wdat_mrk_clr) | w_wdat_mrk_set;
+   assign w_wdat_ena_set  = ({16{ena_set}} & col_dec    );
+   assign w_wdat_ena_clr  = ({16{ena_clr}} & col_dec    );
+   assign w_wdat_mrk_set  = ({16{mrk_set}} & w_rdat_ena );
+   assign w_wdat_mrk_clr  = ({16{mrk_clr}} & col_dec    );
+   assign w_wdat_ena      = (w_rdat_ena & ~w_wdat_ena_clr) | w_wdat_ena_set;
+   assign w_wdat_mrk      = (w_rdat_mrk & ~w_wdat_mrk_clr) | w_wdat_mrk_set;
    
    //
-   assign w_dat15_ena = foo[15] ? w_wdat_ena : bar;
+   assign w_dat15_ena     = foo[15] ? w_wdat_ena : bar;
    
    //
-   assign w_dat15_mrk = foo[15] ? w_wdat_mrk : baz;
+   assign w_dat15_mrk     = foo[15] ? w_wdat_mrk : baz;
    
    //^^^^ FIX NEWLINE ABOVE HERE
    //
-   assign w_timeout_mrk = row_check      ?  w_wdat_mrk        : r_timeout_mrk;
+   assign w_timeout_mrk     = row_check      ?  w_wdat_mrk        : r_timeout_mrk;
    
 endmodule

--- a/tests_ok/indent_bracket.v
+++ b/tests_ok/indent_bracket.v
@@ -6,7 +6,7 @@ module foo
    output [63:0] data_out,
    output        ctl_out);
    
-   assign data_out = data_in[1] ? data_in[63:0]
-                     :            64'h0;
+   assign data_out  = data_in[1] ? data_in[63:0]
+                      :            64'h0;
    
 endmodule

--- a/tests_ok/inject_inst_empty_ports.v
+++ b/tests_ok/inject_inst_empty_ports.v
@@ -21,7 +21,7 @@ module register (
    
    always_ff @(posedge clk or negedge rst_n)
      if (!rst_n) q <= '0;
-   else        q <= d;
+     else        q <= d;
    
    assign qb = ~q;
 endmodule

--- a/tests_ok/inject_inst_endparen.v
+++ b/tests_ok/inject_inst_endparen.v
@@ -31,5 +31,5 @@ module register (
    
    always_ff @(posedge clk or negedge rst_n)
      if (!rst_n) q <= '0;
-   else        q <= d;
+     else        q <= d;
 endmodule

--- a/tests_ok/inject_inst_net_case.v
+++ b/tests_ok/inject_inst_net_case.v
@@ -27,7 +27,7 @@ module register2 (
    
    always_ff @(posedge ck or negedge rst_n)
      if (!rst_n) q2 <= '0;
-   else        q2 <= q1;
+     else        q2 <= q1;
 endmodule
 
 module register1 (
@@ -38,5 +38,5 @@ module register1 (
    
    always_ff @(posedge ck or negedge rst_n)
      if (!rst_n) q1 <= '0;
-   else        q1 <= d;
+     else        q1 <= d;
 endmodule

--- a/tests_ok/inject_inst_param.v
+++ b/tests_ok/inject_inst_param.v
@@ -22,5 +22,5 @@ module register #(parameter WIDTH=4) (
    
    always_ff @(posedge clk or negedge rst_n)
      if (!rst_n) q <= '0;
-   else        q <= d;
+     else        q <= d;
 endmodule

--- a/tests_ok/inject_path_sub.v
+++ b/tests_ok/inject_path_sub.v
@@ -8,7 +8,7 @@ module reg_core (
    
    always_ff @(posedge clk or negedge rst_n)
      if (!rst_n) q <= '0;
-   else        q <= d;
+     else        q <= d;
 endmodule
 
 module register (

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -7519,7 +7519,7 @@ If QUIET is non-nil, do not print messages showing the progress of line-up."
     (unless (verilog-in-comment-or-string-p)
       (save-excursion
         (beginning-of-line)
-        (when (and (verilog--pretty-expr-assignment-found)
+        (when (and (verilog--pretty-expr-assignment-found discard-re-line)
                    (save-excursion
                      (goto-char (match-end 2))
                      (and (not (verilog-in-attribute-p))


### PR DESCRIPTION
Hi,

This PR prevents `verilog-pretty-expr` from aligning lines that do not contain statements that can be aligned (e.g. continuous assignments when `verilog-align-assign-expr` is nil).

Almost all the changes revert the `test_ok/*` tests alignment made by `verilog-pretty-expr` on `else` and `assign` statements. 

Thanks! 
