### PR TITLE
Improve alignment of expressions with verilog-pretty-expr

### DIFF
--- a/tests/align_decl_comments_nil.sv
+++ b/tests/align_decl_comments_nil.sv
@@ -86,6 +86,6 @@ logic [1:0] /* embedded comment should NOT get aligned */ t3;
 endmodule
 
 // Local Variables:
-// verilog-align-declaration-comments: nil
+// verilog-align-decl-expr-comments: nil
 // End:
 

--- a/tests/align_param.sv
+++ b/tests/align_param.sv
@@ -1,0 +1,12 @@
+module align_param # (
+parameter PARAM_1 = 0,
+parameter PARAMETER_2 = 1
+);
+
+localparam LOCAL_1 = 1;
+localparam LOCAL_LONG = 2;
+localparam LOCAL_MULTILINE = 3,
+LOCAL2 = 4,
+LOCAL_LONG3 = 5;
+
+endmodule

--- a/tests/autoinst_param_2d.v
+++ b/tests/autoinst_param_2d.v
@@ -1,6 +1,6 @@
 // bug981
 
-module a(
+module a();
 	 parameter AUM=80;
 	 parameter BUM=70;
 	 parameter VUM=1;
@@ -16,7 +16,6 @@ module a(
 
 	 input PARAMS0__t params0 [1:0];
 	 input PARAMS1__t params1 [1:0];
-	 );
 endmodule
 
 module top (/*AUTOARG*/);

--- a/tests/autoinstparam_belkind_leaf.v
+++ b/tests/autoinstparam_belkind_leaf.v
@@ -1,6 +1,6 @@
 module autoinstparam_belkind_leaf (/*AUTOARG*/) ;
 
-   parameter P =3D 4;
+   parameter P = 3'd4;
    input [P-1:0] a;
 
 endmodule // leaf

--- a/tests/indent_list_nil_param_port_list.sv
+++ b/tests/indent_list_nil_param_port_list.sv
@@ -3,11 +3,11 @@ parameter integer PARAMETER_1 = 0,
 parameter integer PARAMETER_2 = 1,
 parameter integer PARAMETER_3 = 2,
 parameter integer PARAMETER_4 = 3,
-parameter integer PARAMETER_5 = 4,
+parameter integer PARAMETER_5 = 4, // Some other comment
 parameter integer PARAM_6 = 5,
 parameter integer PARAMETER7 = 6,
 parameter integer PARAM_LONGER = 7,
-parameter integer PARAM_EVEN_LONGER = 8,
+parameter integer PARAM_EVEN_LONGER = 8, // Maybe more comments
 parameter integer PARAMETER_10 = 9,
 parameter integer PARAMETER_11 = 10,
 parameter integer PARAMETER_12 = 11,
@@ -40,26 +40,45 @@ logic name_4;
 endmodule
 
 
+
+module param_port_list # (
+parameter PARAMETER_0 = 0,
+parameter integer PARAMETER_11 = 1,
+parameter logic [3:0] PARAMETER_222 = 4'h0
+)(
+input logic clk,
+input logic rst_n,
+input logic [3:0] inputs, // Random comment
+output logic [15:0] outputs
+);
+
+
+assign outputs[3:0] = inputs;
+
+endmodule
+
+
+
 class parameterized_class #(
 type T1=int,
-type T2=int,
-type T3=int
+type T22=int,
+type T333=int
 ) extends base_class;
 
 T1 val;
-T2 val2;
-T3 val3;
+T22 val2;
+T333 val3;
 
 endclass
 
 
 class parameterized_class2 #(type T1=int,
-type T2=int,
-type T3=int) extends base_class;
+type T22=int,
+type T333=int) extends base_class;
 
 T1 val;
-T2 val2;
-T3 val3;
+T22 val2;
+T333 val3;
 
 endclass
 

--- a/tests/param_port_list.sv
+++ b/tests/param_port_list.sv
@@ -3,11 +3,11 @@ parameter integer PARAMETER_1 = 0,
 parameter integer PARAMETER_2 = 1,
 parameter integer PARAMETER_3 = 2,
 parameter integer PARAMETER_4 = 3,
-parameter integer PARAMETER_5 = 4,
+parameter integer PARAMETER_5 = 4, // Some other comment
 parameter integer PARAM_6 = 5,
 parameter integer PARAMETER7 = 6,
 parameter integer PARAM_LONGER = 7,
-parameter integer PARAM_EVEN_LONGER = 8,
+parameter integer PARAM_EVEN_LONGER = 8, // Maybe more comments
 parameter integer PARAMETER_10 = 9,
 parameter integer PARAMETER_11 = 10,
 parameter integer PARAMETER_12 = 11,
@@ -40,26 +40,45 @@ logic name_4;
 endmodule
 
 
+
+module param_port_list # (
+parameter PARAMETER_0 = 0,
+parameter integer PARAMETER_11 = 1,
+parameter logic [3:0] PARAMETER_222 = 4'h0
+)(
+input logic clk,
+input logic rst_n,
+input logic [3:0] inputs, // Random comment
+output logic [15:0] outputs
+);
+
+
+assign outputs[3:0] = inputs;
+
+endmodule
+
+
+
 class parameterized_class #(
 type T1=int,
-type T2=int,
-type T3=int
+type T22=int,
+type T333=int
 ) extends base_class;
 
 T1 val;
-T2 val2;
-T3 val3;
+T22 val2;
+T333 val3;
 
 endclass
 
 
 class parameterized_class2 #(type T1=int,
-type T2=int,
-type T3=int) extends base_class;
+type T22=int,
+type T333=int) extends base_class;
 
 T1 val;
-T2 val2;
-T3 val3;
+T22 val2;
+T333 val3;
 
 endclass
 

--- a/tests_ok/ExampParamVal1.v
+++ b/tests_ok/ExampParamVal1.v
@@ -1,7 +1,7 @@
 module InstModule (o,i);
    parameter         WIDTH;
    input [WIDTH-1:0] i;
-   parameter         type OUT_t;
+   parameter type    OUT_t;
    output            OUT_t o;
 endmodule
 

--- a/tests_ok/ExampParamVal2.v
+++ b/tests_ok/ExampParamVal2.v
@@ -1,7 +1,7 @@
 module InstModule (o,i);
    parameter         WIDTH;
    input [WIDTH-1:0] i;
-   parameter         type OUT_t;
+   parameter type    OUT_t;
    output            OUT_t o;
 endmodule
 

--- a/tests_ok/abc.sv
+++ b/tests_ok/abc.sv
@@ -4,12 +4,12 @@ covergroup CB;
      {
       bins a0 = {0};
       bins a1 = {1};
-      option.weight=0;
+      option.weight = 0;
    }
    b: coverpoint tr.b {
       bins b0 = {0};
       bins b1 = {1};
-      option.weight=0;
+      option.weight = 0;
    }
    ab: cross a,b {
       bins a0b0 = binsof(a.a0) && binsof(b.b0);

--- a/tests_ok/align_decl_comments_nil.sv
+++ b/tests_ok/align_decl_comments_nil.sv
@@ -86,6 +86,6 @@ module foo
 endmodule
 
 // Local Variables:
-// verilog-align-declaration-comments: nil
+// verilog-align-decl-expr-comments: nil
 // End:
 

--- a/tests_ok/align_param.sv
+++ b/tests_ok/align_param.sv
@@ -1,0 +1,12 @@
+module align_param # (
+                      parameter PARAM_1     = 0,
+                      parameter PARAMETER_2 = 1
+                      );
+   
+   localparam LOCAL_1         = 1;
+   localparam LOCAL_LONG      = 2;
+   localparam LOCAL_MULTILINE = 3,
+              LOCAL2          = 4,
+              LOCAL_LONG3     = 5;
+   
+endmodule

--- a/tests_ok/autoinst_2k_fredriksen.v
+++ b/tests_ok/autoinst_2k_fredriksen.v
@@ -10,9 +10,9 @@ module top ();
 endmodule // top
 
 module sub
-  #(parameter PARAM1=2,
-    PARAM2=3,
-    PARAM3=6)
+  #(parameter PARAM1 = 2,
+    PARAM2           = 3,
+    PARAM3           = 6)
    ( input wire [PARAM1:0] a,
      output reg [PARAM2:0] b
      );

--- a/tests_ok/autoinst_iface_noparam.v
+++ b/tests_ok/autoinst_iface_noparam.v
@@ -1,6 +1,6 @@
 // bug1253
 
-interface iface #(D  = 64) (input bit clk);
+interface iface #(D = 64) (input bit clk);
    logic clk;
 endinterface: iface
 

--- a/tests_ok/autoinst_param_2d.v
+++ b/tests_ok/autoinst_param_2d.v
@@ -1,22 +1,21 @@
 // bug981
 
-module a(
-         parameter                AUM=80;
-         parameter                BUM=70;
-         parameter                VUM=1;
-         parameter                V2=2;
-         input                    my_data_z;
-         input                    my_data_v[VUM];
-         input                    my_data_vv[VUM][V2];
-         input [AUM-1:0]          my_data_av[VUM];
-         input [AUM-1:0][BUM-1:0] my_data_ab;
-         input [AUM-1:0][BUM-1:0] my_data_abv[VUM];
-         
-         input [XUM-1:0][YUM-1:0] my_data_xyz[ZUM];
-         
-         input                    PARAMS0__t params0 [1:0];
-         input                    PARAMS1__t params1 [1:0];
-         );
+module a();
+   parameter                AUM = 80;
+   parameter                BUM = 70;
+   parameter                VUM = 1;
+   parameter                V2 = 2;
+   input                    my_data_z;
+   input                    my_data_v[VUM];
+   input                    my_data_vv[VUM][V2];
+   input [AUM-1:0]          my_data_av[VUM];
+   input [AUM-1:0][BUM-1:0] my_data_ab;
+   input [AUM-1:0][BUM-1:0] my_data_abv[VUM];
+   
+   input [XUM-1:0][YUM-1:0] my_data_xyz[ZUM];
+   
+   input                    PARAMS0__t params0 [1:0];
+   input                    PARAMS1__t params1 [1:0];
 endmodule
 
 module top (/*AUTOARG*/

--- a/tests_ok/autoinst_param_cmt.v
+++ b/tests_ok/autoinst_param_cmt.v
@@ -3,7 +3,7 @@ module InstMod ( ins, outs );
 endmodule
 
 module test (/*AUTOARG*/) ;
-   parameter foo=1;
+   parameter foo = 1;
    /*
     parameter foo=2;
     */

--- a/tests_ok/autoinst_param_type.v
+++ b/tests_ok/autoinst_param_type.v
@@ -41,7 +41,7 @@ module ptype
 endmodule
 
 module ptype_buf
-  #(parameter WIDTH = 1,
+  #(parameter      WIDTH  = 1,
     parameter type TYPE_T = logic [WIDTH-1:0])
    (output TYPE_T y,
     input  TYPE_T a);
@@ -55,7 +55,7 @@ endmodule
 module InstModule (o,i);
    parameter         WIDTH;
    input [WIDTH-1:0] i;
-   parameter         type OUT_t;
+   parameter type    OUT_t;
    output            OUT_t o;
 endmodule
 

--- a/tests_ok/autoinst_sv_kulkarni.v
+++ b/tests_ok/autoinst_sv_kulkarni.v
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------------
 module a_h
   // Verilog 2001 style
-  #(parameter M=5, N=3)
+  #(parameter M = 5, N=3)
    (
     // Outputs
     output [N-1:0] [M-1:0] a_o1 // From Ia of autoinst_sv_kulkarni_base.v
@@ -33,8 +33,8 @@ endmodule
 // Top-level module or Testbench
 // -----------------------------------------------------------------------------
 module top;
-   parameter            M=4;
-   parameter            N=2;
+   parameter            M = 4;
+   parameter            N = 2;
    
    wire [N-1:0]         a_o1;
    logic [N-1:0][M-1:0] a_i1;

--- a/tests_ok/autoinst_sv_kulkarni_base.v
+++ b/tests_ok/autoinst_sv_kulkarni_base.v
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------------
 module autoinst_sv_kulkarni_base
   // Verilog 2001 style
-  #(parameter M=5, N=3)
+  #(parameter M = 5, N=3)
    (
     output logic [N-1:0][M-1:0] a_o1,
     input [N-1:0][M-1:0]        a_i1

--- a/tests_ok/autoinst_sv_kulkarni_wire.v
+++ b/tests_ok/autoinst_sv_kulkarni_wire.v
@@ -1,7 +1,7 @@
 `timescale 1ns/100ps
 
 module a_h
-  #(parameter M=5, N=3)
+  #(parameter M = 5, N=3)
    ();
    
    /*AUTOWIRE*/

--- a/tests_ok/autoinst_tennant.v
+++ b/tests_ok/autoinst_tennant.v
@@ -1,8 +1,8 @@
 typedef logic [3:0][1:0] sometype_t;
 
 module top
-  #(parameter X=4,
-    parameter Y=1)
+  #(parameter X = 4,
+    parameter Y = 1)
    
    (input              clk,
     input              rstb,
@@ -63,8 +63,8 @@ module top
 endmodule // top
 
 module xx
-  #(parameter X=4,
-    parameter Y=1)
+  #(parameter X = 4,
+    parameter Y = 1)
    (input              clk,
     input              rstb,
     
@@ -83,8 +83,8 @@ module xx
 endmodule // xx
 
 module yy
-  #(parameter X=4,
-    parameter Y=1)
+  #(parameter X = 4,
+    parameter Y = 1)
    (input               clk,
     input               rstb,
     

--- a/tests_ok/autoinst_unsigned_bug302.v
+++ b/tests_ok/autoinst_unsigned_bug302.v
@@ -16,9 +16,9 @@ module Sub
   #(
     parameter              No1 = 6,
     parameter int unsigned No2                  // Parameter no. 2
-                           = pa_Abc::No2,
+                               = pa_Abc::No2,
     parameter bit          No3 [No1:0][No2-1:0] // Parameter no. 3
-    = pa_Abc::No3
+                               = pa_Abc::No3
     )
    
    (

--- a/tests_ok/autoinstparam_belkind_leaf.v
+++ b/tests_ok/autoinstparam_belkind_leaf.v
@@ -3,7 +3,7 @@ module autoinstparam_belkind_leaf (/*AUTOARG*/
                                    a
                                    ) ;
    
-   parameter     P =3D 4;
+   parameter     P = 3'd4;
    input [P-1:0] a;
    
 endmodule // leaf

--- a/tests_ok/autoinstparam_first.v
+++ b/tests_ok/autoinstparam_first.v
@@ -1,7 +1,7 @@
 module autoinstparam_first ();
    
-   parameter BITSCHANGED;
-   parameter BITSA;
+   parameter      BITSCHANGED;
+   parameter      BITSA;
    parameter type BITSB_t;
    typedef [2:0] my_bitsb_t;
    

--- a/tests_ok/autoinstparam_first_sub.v
+++ b/tests_ok/autoinstparam_first_sub.v
@@ -9,7 +9,7 @@ module autoinstparam_first_sub (/*AUTOARG*/
    
    localparam      IGNORED;
    parameter       BITSA;
-   parameter       type BITSB_t = bit; // See bug340
+   parameter type  BITSB_t = bit; // See bug340
    
    inout [BITSA:0] a;
    inout           BITSB_t b;

--- a/tests_ok/autoinstparam_iface_bruce.v
+++ b/tests_ok/autoinstparam_iface_bruce.v
@@ -13,7 +13,7 @@ endmodule
 module sub0
   #(
     parameter string testit2 = 0,
-    int              TESTIT = 0
+    int              TESTIT  = 0
     ) (
        // clk and resets
        input logic side_clk,

--- a/tests_ok/autoinstparam_int.v
+++ b/tests_ok/autoinstparam_int.v
@@ -1,7 +1,7 @@
 module xyz
-  #(parameter int         FOO=1, BAR=2,
-    parameter logic [5:0] BLUP=3, ZOT=4,
-    parameter             LDWRDS=5)
+  #(parameter int         FOO    = 1, BAR=2,
+    parameter logic [5:0] BLUP   = 3, ZOT=4,
+    parameter             LDWRDS = 5)
    ( input             x1, x2,
      input int         i1, i2,
      input logic [5:0] i3, i4,
@@ -11,7 +11,7 @@ endmodule
 
 module pdq;
    input         x; output y;
-   parameter int FOO=1;
+   parameter int FOO = 1;
 endmodule
 
 module abc;

--- a/tests_ok/autoinstparam_local.v
+++ b/tests_ok/autoinstparam_local.v
@@ -1,7 +1,7 @@
 //bug889
 
 module leaf #(
-              parameter  DATA_WIDTH = 256,
+              parameter  DATA_WIDTH                  = 256,
               localparam STRB_WIDTH_SHOULD_BE_HIDDEN = DATA_WIDTH/8 )
    ();
 endmodule

--- a/tests_ok/autologic_bracket.v
+++ b/tests_ok/autologic_bracket.v
@@ -1,7 +1,7 @@
 module sub1
   #(
-    parameter integer AAA= {32'd4,32'd8},
-    parameter integer BBB= 1
+    parameter integer AAA = {32'd4,32'd8},
+    parameter integer BBB = 1
     )
    (
     output [AAA[BBB] -1:0] out_signal

--- a/tests_ok/autooutput_cast.v
+++ b/tests_ok/autooutput_cast.v
@@ -30,14 +30,14 @@ module bug1526;
 endmodule
 
 module t2 #(
-            parameter N=4
+            parameter N = 4
             ) (
                output [N-1:0][27:0] x
                );
 endmodule
 
 module t3 #(
-            parameter N=4
+            parameter N = 4
             ) (
                input [N-1:0][27:0] x
                );

--- a/tests_ok/autoreg_outreg.v
+++ b/tests_ok/autoreg_outreg.v
@@ -1,6 +1,6 @@
 module foo
   #(parameter
-    PARAM3_P=99)
+    PARAM3_P = 99)
    (
     output                     sig3,   // Here, I've hit "tab" twice and this line is correct
     output reg [PARAM2_P-1:0]  s4,     // Comment here which should be at "comment-column"

--- a/tests_ok/autoreset_assert.v
+++ b/tests_ok/autoreset_assert.v
@@ -15,8 +15,8 @@ module foo;
         // End of automatics
      end
      else begin
-        a<=b;
-        b<=a;
+        a <= b;
+        b <= a;
      end
    
 endmodule

--- a/tests_ok/autoreset_label_gorfajn.v
+++ b/tests_ok/autoreset_label_gorfajn.v
@@ -8,9 +8,9 @@ module autoreset_label_gorfajn;
         z <= 1'h0;
         // End of automatics
      end else begin
-        a<=b;
+        a <= b;
         foo: assert (b==4);
-        bar: z<=1;
+        bar: z <= 1;
      end
    
 endmodule

--- a/tests_ok/autoreset_struct.v
+++ b/tests_ok/autoreset_struct.v
@@ -35,7 +35,7 @@ module gminstdecode
    end
    
    always_comb begin
-      instClass.iFunc  = IFUNC_ADD;  // #2
+      instClass.iFunc  = IFUNC_ADD; // #2
       /*AUTORESET*/
       // Beginning of autoreset for uninitialized flops
       instClass.isBool = '0;

--- a/tests_ok/autosense_inandout.v
+++ b/tests_ok/autosense_inandout.v
@@ -6,8 +6,8 @@ module autosense_inandout(a,b);
    reg    c;
    
    always @(/*AUTOSENSE*/a) begin
-      c=a;
-      b=c;
+      c = a;
+      b = c;
    end
    
 endmodule

--- a/tests_ok/autosense_inc_param.v
+++ b/tests_ok/autosense_inc_param.v
@@ -1,3 +1,3 @@
-parameter [2:0] PARAM_TWO = 2,
+parameter [2:0] PARAM_TWO   = 2,
                 PARAM_THREE = 3;
-parameter PARAM_FOUR = 4;
+parameter PARAM_FOUR        = 4;

--- a/tests_ok/autosense_lavinge.v
+++ b/tests_ok/autosense_lavinge.v
@@ -1,5 +1,5 @@
 module test
-  #(parameter FOO=1)
+  #(parameter FOO = 1)
    ( a, b );
    input a;
    input b;
@@ -9,7 +9,7 @@ module test
    
    always @(/*AUTOSENSE*/b or d)
      begin
-        c=0;
+        c = 0;
         if (d) c = b;
      end
 endmodule

--- a/tests_ok/autosense_mcardle_onehot.v
+++ b/tests_ok/autosense_mcardle_onehot.v
@@ -5,9 +5,9 @@ module x;
    
    parameter    CYCLEA = 1;
    parameter    CYCLEC = 2;
-   parameter    MSTRA = 3;
-   parameter    MSTRB = 4;
-   parameter    MSTRC = 5;
+   parameter    MSTRA  = 3;
+   parameter    MSTRB  = 4;
+   parameter    MSTRC  = 5;
    
    // make sure 'state' is listed
    always @ (/*AUTOSENSE*/done or nREQA or nREQB or nREQC or state) begin

--- a/tests_ok/autounused.v
+++ b/tests_ok/autounused.v
@@ -1,11 +1,11 @@
 module wbuf
-  #(parameter width=1)
+  #(parameter width = 1)
    (output [width-1:0] q,
     input [width-1:0]  d);
 endmodule
 
 module autounused
-  #(parameter width=3)
+  #(parameter width = 3)
    (/*AUTOARG*/
     // Outputs
     q,

--- a/tests_ok/autowire_paramvec_bug302.v
+++ b/tests_ok/autowire_paramvec_bug302.v
@@ -33,9 +33,9 @@ module Abc
   #(
     parameter              No1 = 6,
     parameter int unsigned No2                  // Parameter no. 2
-                           = pa_Abc::No2,
+                               = pa_Abc::No2,
     parameter bit          No3 [No1:0][No2-1:0] // Parameter no. 3
-    = pa_Abc::No3
+                               = pa_Abc::No3
     )
    (
     input logic                 ck,

--- a/tests_ok/autowire_red_bracket.v
+++ b/tests_ok/autowire_red_bracket.v
@@ -1,7 +1,7 @@
 
 module top
   #(
-    parameter         NOF_TEST = 6,
+    parameter         NOF_TEST        = 6,
     parameter integer TEST [NOF_TEST] = '{10,20,30,40,50,60}
     )
    
@@ -30,7 +30,7 @@ module top
 endmodule
 
 module submod
-  #(parameter  NUM_MEM        = 6
+  #(parameter  NUM_MEM = 6
     )
    (output [NUM_MEM-1:0] x);
 endmodule

--- a/tests_ok/autowire_width_muldiv.v
+++ b/tests_ok/autowire_width_muldiv.v
@@ -24,13 +24,13 @@ module test
 endmodule
 
 module subtestin
-  #(parameter WIDTH=0)
+  #(parameter WIDTH = 0)
    (input wire [WIDTH*2/8-1:0] signal
     /*AUTOARG*/);
 endmodule
 
 module subtestout
-  #(parameter WIDTH=0)
+  #(parameter WIDTH = 0)
    (output wire [WIDTH*2/8-1:0] signal
     /*AUTOARG*/);
    assign signal = 0;

--- a/tests_ok/batch_li_child.v
+++ b/tests_ok/batch_li_child.v
@@ -1,7 +1,7 @@
 module batch_li_child
   #(parameter
     
-    WIDTH_0= 'h8,
+    WIDTH_0 = 'h8,
     WIDTH_1 = 'h4
     )
    (

--- a/tests_ok/debug.v
+++ b/tests_ok/debug.v
@@ -8,8 +8,8 @@ module z();
    g                       = r;
    fgasdfasdfasdfasfdasfd <= p;
    gh                     := h;
-   gf                        <=g;
-   ssdf = 5;
-   f    = zsfdsdf >= f;
+   gf                     <= g;
+   ssdf                    = 5;
+   f                       = zsfdsdf >= f;
    
 endmodule

--- a/tests_ok/indent_analog.v
+++ b/tests_ok/indent_analog.v
@@ -1,7 +1,7 @@
 
 module mymodule();
-   parameter real fc=10e6;
-   parameter real bw=25e3;
+   parameter real fc = 10e6;
+   parameter real bw = 25e3;
    analog begin
       // contents of module here
    end

--- a/tests_ok/indent_connectmodule.v
+++ b/tests_ok/indent_connectmodule.v
@@ -2,7 +2,7 @@
 connectmodule Wreal2L(input wreal w, output wire l);
    logic          lval;
    
-   parameter real vsup = 1.8;
+   parameter real vsup   = 1.8;
    parameter real vth_hi = 0.7*vsup;
    parameter real vth_lo = 0.3*vsup;
    always begin

--- a/tests_ok/indent_list_nil_generate_for.v
+++ b/tests_ok/indent_list_nil_generate_for.v
@@ -4,7 +4,7 @@ module foo (
    output reg z
 );
    
-   localparam CONST=1;
+   localparam CONST = 1;
    
    generate
       for (genvar i=0; i<CONST; i++) begin : label

--- a/tests_ok/indent_list_nil_generate_for2.v
+++ b/tests_ok/indent_list_nil_generate_for2.v
@@ -4,7 +4,7 @@ module foo (
    output reg z
 );
    
-   localparam CONST=1;
+   localparam CONST = 1;
    
    generate
       for (genvar i=0; i<CONST; i++)

--- a/tests_ok/indent_list_nil_param_port_list.sv
+++ b/tests_ok/indent_list_nil_param_port_list.sv
@@ -1,17 +1,17 @@
-module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
-                          parameter integer PARAMETER_1 = 0,
-                          parameter integer PARAMETER_2 = 1,
-                          parameter integer PARAMETER_3 = 2,
-                          parameter integer PARAMETER_4 = 3,
-                          parameter integer PARAMETER_5 = 4,
-                          parameter integer PARAM_6 = 5,
-                          parameter integer PARAMETER7 = 6,
-                          parameter integer PARAM_LONGER = 7,
-                          parameter integer PARAM_EVEN_LONGER = 8,
-                          parameter integer PARAMETER_10 = 9,
-                          parameter integer PARAMETER_11 = 10,
-                          parameter integer PARAMETER_12 = 11,
-                          parameter integer PARAMETER_13 = 12)
+module param_port_list # (parameter integer PARAMETER_0       = 0, // Some comment
+                          parameter integer PARAMETER_1       = 0,
+                          parameter integer PARAMETER_2       = 1,
+                          parameter integer PARAMETER_3       = 2,
+                          parameter integer PARAMETER_4       = 3,
+                          parameter integer PARAMETER_5       = 4, // Some other comment
+                          parameter integer PARAM_6           = 5,
+                          parameter integer PARAMETER7        = 6,
+                          parameter integer PARAM_LONGER      = 7,
+                          parameter integer PARAM_EVEN_LONGER = 8, // Maybe more comments
+                          parameter integer PARAMETER_10      = 9,
+                          parameter integer PARAMETER_11      = 10,
+                          parameter integer PARAMETER_12      = 11,
+                          parameter integer PARAMETER_13      = 12)
    (
    input logic                    clk,
    input logic                    rst_n,
@@ -27,7 +27,7 @@ module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
    input logic                    packed_array [PARAMETER_5][PARAMETER_6], // Another random comment
    input logic [4:0][3:0]         unpacked_array,                          // More comments
    input logic [4:0]              unpacked_array_2                         // Last comment
-   );
+);
    
    typedef struct packed{
       logic       name1;
@@ -40,26 +40,45 @@ module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
 endmodule
 
 
+
+module param_port_list # (
+   parameter             PARAMETER_0   = 0,
+   parameter integer     PARAMETER_11  = 1,
+   parameter logic [3:0] PARAMETER_222 = 4'h0
+)(
+   input logic         clk,
+   input logic         rst_n,
+   input logic [3:0]   inputs, // Random comment
+   output logic [15:0] outputs
+);
+   
+   
+   assign outputs[3:0] = inputs;
+   
+endmodule
+
+
+
 class parameterized_class #(
-   type T1=int,
-   type T2=int,
-   type T3=int
+   type T1   = int,
+   type T22  = int,
+   type T333 = int
 ) extends base_class;
    
    T1 val;
-   T2 val2;
-   T3 val3;
+   T22 val2;
+   T333 val3;
    
 endclass
 
 
-class parameterized_class2 #(type T1=int,
-                             type T2=int,
-                             type T3=int) extends base_class;
+class parameterized_class2 #(type T1   = int,
+                             type T22  = int,
+                             type T333 = int) extends base_class;
    
    T1 val;
-   T2 val2;
-   T3 val3;
+   T22 val2;
+   T333 val3;
    
 endclass
 

--- a/tests_ok/indent_list_nil_params2.v
+++ b/tests_ok/indent_list_nil_params2.v
@@ -1,8 +1,8 @@
 module foo # (
    parameter A = 0,
-   B = 0,
-   C = 0,
-   D = 0
+   B           = 0,
+   C           = 0,
+   D           = 0
 )(
    input wire a,
    input wire b,

--- a/tests_ok/indent_param.v
+++ b/tests_ok/indent_param.v
@@ -1,9 +1,9 @@
 module example_block
   #(
     parameter PARAM = 1,
-    FOO = 2,
-    BARFLUG = 4,
-    G = 5,
+    FOO             = 2,
+    BARFLUG         = 4,
+    G               = 5,
     )
    (// I/O
     input      reset_n,

--- a/tests_ok/indent_rep_msg1188.v
+++ b/tests_ok/indent_rep_msg1188.v
@@ -8,8 +8,8 @@ module test;
          c = {par_a{1'b0}};
       end
       else begin
-         b=i_blc+I_cdef;
-         c=b;
+         b = i_blc+I_cdef;
+         c = b;
       end
    end
 endmodule // test

--- a/tests_ok/label_analog.v
+++ b/tests_ok/label_analog.v
@@ -1,6 +1,6 @@
 module mymodule();
-   parameter real fc=10e6;
-   parameter real bw=25e3;
+   parameter real fc = 10e6;
+   parameter real bw = 25e3;
    
    analog begin
       // contents of module here

--- a/tests_ok/label_class2.v
+++ b/tests_ok/label_class2.v
@@ -1,13 +1,13 @@
 // bug1259
 
 class trial_good; // this works because the variable class_name has been renamed clazz_name
-   string clazz_name="trial_good";
+   string clazz_name = "trial_good";
    function void f();
    endfunction // f
 endclass // trial_good
 
 class trial_bad; // this fools the autocommenter, that ends reporting "function" as class name
-   string class_name="trial_bad";
+   string class_name = "trial_bad";
    function void f();
    endfunction // f
 endclass // trial_bad

--- a/tests_ok/label_connectmodule.v
+++ b/tests_ok/label_connectmodule.v
@@ -2,7 +2,7 @@
 connectmodule Wreal2L(input wreal w, output wire l);
    logic          lval;
    
-   parameter real vsup = 1.8;
+   parameter real vsup   = 1.8;
    parameter real vth_hi = 0.7*vsup;
    parameter real vth_lo = 0.3*vsup;
    always begin

--- a/tests_ok/param_port_list.sv
+++ b/tests_ok/param_port_list.sv
@@ -1,17 +1,17 @@
-module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
-                          parameter integer PARAMETER_1 = 0,
-                          parameter integer PARAMETER_2 = 1,
-                          parameter integer PARAMETER_3 = 2,
-                          parameter integer PARAMETER_4 = 3,
-                          parameter integer PARAMETER_5 = 4,
-                          parameter integer PARAM_6 = 5,
-                          parameter integer PARAMETER7 = 6,
-                          parameter integer PARAM_LONGER = 7,
-                          parameter integer PARAM_EVEN_LONGER = 8,
-                          parameter integer PARAMETER_10 = 9,
-                          parameter integer PARAMETER_11 = 10,
-                          parameter integer PARAMETER_12 = 11,
-                          parameter integer PARAMETER_13 = 12)
+module param_port_list # (parameter integer PARAMETER_0       = 0, // Some comment
+                          parameter integer PARAMETER_1       = 0,
+                          parameter integer PARAMETER_2       = 1,
+                          parameter integer PARAMETER_3       = 2,
+                          parameter integer PARAMETER_4       = 3,
+                          parameter integer PARAMETER_5       = 4, // Some other comment
+                          parameter integer PARAM_6           = 5,
+                          parameter integer PARAMETER7        = 6,
+                          parameter integer PARAM_LONGER      = 7,
+                          parameter integer PARAM_EVEN_LONGER = 8, // Maybe more comments
+                          parameter integer PARAMETER_10      = 9,
+                          parameter integer PARAMETER_11      = 10,
+                          parameter integer PARAMETER_12      = 11,
+                          parameter integer PARAMETER_13      = 12)
    (
     input logic                    clk,
     input logic                    rst_n,
@@ -40,26 +40,45 @@ module param_port_list # (parameter integer PARAMETER_0 = 0, // Some comment
 endmodule
 
 
+
+module param_port_list # (
+                          parameter             PARAMETER_0   = 0,
+                          parameter integer     PARAMETER_11  = 1,
+                          parameter logic [3:0] PARAMETER_222 = 4'h0
+                          )(
+                            input logic         clk,
+                            input logic         rst_n,
+                            input logic [3:0]   inputs, // Random comment
+                            output logic [15:0] outputs
+                            );
+   
+   
+   assign outputs[3:0] = inputs;
+   
+endmodule
+
+
+
 class parameterized_class #(
-                            type T1=int,
-                            type T2=int,
-                            type T3=int
+                            type T1   = int,
+                            type T22  = int,
+                            type T333 = int
                             ) extends base_class;
    
    T1 val;
-   T2 val2;
-   T3 val3;
+   T22 val2;
+   T333 val3;
    
 endclass
 
 
-class parameterized_class2 #(type T1=int,
-                             type T2=int,
-                             type T3=int) extends base_class;
+class parameterized_class2 #(type T1   = int,
+                             type T22  = int,
+                             type T333 = int) extends base_class;
    
    T1 val;
-   T2 val2;
-   T3 val3;
+   T22 val2;
+   T333 val3;
    
 endclass
 

--- a/tests_ok/property_test.v
+++ b/tests_ok/property_test.v
@@ -24,7 +24,7 @@ module test();
    //**********************************************************************
    
    initial begin
-      count=0;
+      count = 0;
    end
    
    always @(posedge test_clk) begin

--- a/tests_ok/testcases.v
+++ b/tests_ok/testcases.v
@@ -50,7 +50,7 @@ module testmodule (/*AUTOARG*/
    reg [7:0]    outw3;
    // End of automatics
    
-   wire         outb8=1'b1, outb9=|{in1[0],in2[0]}, outb10=1'b0;
+   wire         outb8 = 1'b1, outb9=|{in1[0],in2[0]}, outb10=1'b0;
    
    always @(/*AUTOSENSE*/in1 or in2 or in3 or in4) begin
       :ignore_label
@@ -64,12 +64,12 @@ module testmodule (/*AUTOARG*/
    
    always @ (/*AUTOSENSE*/in1 or in2 or in3 or in5) begin
       casex ({in5[1:0], (3'b010==in2)})
-        3'bx_1_0: out5=3'b000;
-        3'bx_1_1: out5=3'b010;
-        3'bx_0_x: out5=3'b100;
+        3'bx_1_0: out5 = 3'b000;
+        3'bx_1_1: out5 = 3'b010;
+        3'bx_0_x: out5 = 3'b100;
       endcase
       casex ({in3[in1]})
-        1'bx: out5=3'b000;
+        1'bx: out5 = 3'b000;
       endcase
    end
    
@@ -108,7 +108,7 @@ module testmodule (/*AUTOARG*/
    
    parameter READ = 3'b111,
              //WRITE = 3'b111,
-             CFG = 3'b010;
+             CFG  = 3'b010;
    //supply1   one;
    
    always @(/*AUTOSENSE*/in1 or in2) begin


### PR DESCRIPTION
Hi,

This PR improves the function `verilog-pretty-expr` by adding the following:

- Support alignment of inline comments after `verilog-pretty-expr` (similar to what is already done after `verilog-pretty-declarations`) 
- Variable controlled alignment of parameter/localparam expressions
- Support for expression alignment in parameter port lists
- Support declaration/expression alignment of `type` parameters
- Alignment of expressions that do not have blanks before/after operator char (seemed a bug)
- Fix on functions that did not work as expected for this use case:
  (`verilog-in-attribute-p`, `verilog-in-parameter-p`, `verilog-get-lineup-indent-2`)
- Use markers in `verilog-pretty-expr` to avoid bugs while iterating through the expressions

The alignment of parameter/localparam expressions is controlled through the new variable `verilog-align-param-expr` set to t by default.

There are some new tests to ensure backwards compatibility if `verilog-align-param-expr` is nil. I also created another branch to compare the changes on the tests if this feature is disabled (09b2212)

Thanks!