### PR TITLE
Tests: add testcases for issues 1272, 960, 955 and 585

### DIFF
--- a/tests/align_bug1272.sv
+++ b/tests/align_bug1272.sv
@@ -1,0 +1,33 @@
+// Issue #1272
+
+import bar_pkg1::*;
+import foo_pkg1::*;
+
+module alignment_test
+import bar_pkg2::*;
+import foo_pkg2::*;
+     #(
+       parameter DATA_WIDTH = 8,
+       parameter ADDR_WIDTH = 4
+       )
+     (
+      input wire                  clk,
+      input wire                  res_n,
+      input wire                  valid,
+      input wire [DATA_WIDHT-1:0] data_in,
+      input wire [ADDR_WIDTH-1:0] addr,
+      output logic                accept
+      );
+
+     import bar_pkg3::*;
+     import foo_pkg3::*;
+
+     localparam LP_BAR_0 = 1;
+     localparam LP_BAR_100 = 100;
+     localparam logic [3:0]       LP_BAR_5 = 5;
+
+endmodule
+
+// Local Variables:
+// verilog-auto-lineup: all
+// End:

--- a/tests/align_bug585.sv
+++ b/tests/align_bug585.sv
@@ -1,0 +1,14 @@
+// Issue #585
+
+module bug585;
+parameter ABC = 1;
+parameter integer ABC = 1;
+endmodule
+
+module bug585_ext;
+parameter ABC = 1;
+parameter integer ABCD = 1;
+parameter logic [3:0] ABCDE = 4'hF;
+localparam ABCDEF = 1;
+localparam logic [15:0] ABCDEFG = 16'hFACE;
+endmodule

--- a/tests/align_bug960.sv
+++ b/tests/align_bug960.sv
@@ -1,0 +1,16 @@
+// Issue #960
+
+module img_cnt(
+               logic clk,
+               logic rst,
+               logic frame_vld,
+               logic line_vld,
+               logic data_vld
+               );
+
+   // Expect to restart the alignment from here
+   int unsigned      frame_cnt = 0;
+   int unsigned      line_cnt = 0;
+   int unsigned      data_cnt = 0;
+
+endmodule

--- a/tests/indent_replicate_bug955.sv
+++ b/tests/indent_replicate_bug955.sv
@@ -1,0 +1,12 @@
+// Issue #955
+
+module test (input a, input b, output c);
+        parameter s = 4;
+        reg [s:0] myreg;
+        always @(posedge a) begin
+               if (b) begin
+                  r <= {s{1'b0}};
+               end // <-- this end will be improperly indented unless
+            // 's' is replaced with e.g. 4
+        end
+end

--- a/tests_ok/align_bug1272.sv
+++ b/tests_ok/align_bug1272.sv
@@ -1,0 +1,33 @@
+// Issue #1272
+
+import bar_pkg1::*;
+import foo_pkg1::*;
+
+module alignment_test
+  import bar_pkg2::*;
+   import foo_pkg2::*;
+   #(
+     parameter DATA_WIDTH = 8,
+     parameter ADDR_WIDTH = 4
+     )
+   (
+    input wire                  clk,
+    input wire                  res_n,
+    input wire                  valid,
+    input wire [DATA_WIDHT-1:0] data_in,
+    input wire [ADDR_WIDTH-1:0] addr,
+    output logic                accept
+    );
+   
+   import bar_pkg3::*;
+   import foo_pkg3::*;
+   
+   localparam             LP_BAR_0   = 1;
+   localparam             LP_BAR_100 = 100;
+   localparam logic [3:0] LP_BAR_5   = 5;
+   
+endmodule
+
+// Local Variables:
+// verilog-auto-lineup: all
+// End:

--- a/tests_ok/align_bug585.sv
+++ b/tests_ok/align_bug585.sv
@@ -1,0 +1,14 @@
+// Issue #585
+
+module bug585;
+   parameter         ABC = 1;
+   parameter integer ABC = 1;
+endmodule
+
+module bug585_ext;
+   parameter               ABC     = 1;
+   parameter integer       ABCD    = 1;
+   parameter logic [3:0]   ABCDE   = 4'hF;
+   localparam              ABCDEF  = 1;
+   localparam logic [15:0] ABCDEFG = 16'hFACE;
+endmodule

--- a/tests_ok/align_bug960.sv
+++ b/tests_ok/align_bug960.sv
@@ -1,0 +1,16 @@
+// Issue #960
+
+module img_cnt(
+               logic clk,
+               logic rst,
+               logic frame_vld,
+               logic line_vld,
+               logic data_vld
+               );
+   
+   // Expect to restart the alignment from here
+   int unsigned frame_cnt = 0;
+   int unsigned line_cnt  = 0;
+   int unsigned data_cnt  = 0;
+   
+endmodule

--- a/tests_ok/indent_replicate_bug955.sv
+++ b/tests_ok/indent_replicate_bug955.sv
@@ -1,0 +1,12 @@
+// Issue #955
+
+module test (input a, input b, output c);
+   parameter s = 4;
+   reg [s:0] myreg;
+   always @(posedge a) begin
+      if (b) begin
+         r <= {s{1'b0}};
+      end // <-- this end will be improperly indented unless
+      // 's' is replaced with e.g. 4
+   end
+end


### PR DESCRIPTION
Hi,

This PR adds test files for various issues:
- #585
  - Fixed after #1798 
- #960
  - Works fine
- #955 
  - Works fine
- #1272 
  -  Everything indents and aligns correctly except for package imports between module identifier and parameter list. Even though this seems supported by simulators (tested in Xcelium 19.09) I do not think it would be worth the effort looking into it since package importing in the unit space and after ports list already indents correctly.
```verilog
module alignment_test
  import bar_pkg2::*;
   import foo_pkg2::*;
   #(
```

Thanks!