### PR TITLE
Add support for alignment of user defined types.

### DIFF
--- a/tests/ExampParamVal1.v
+++ b/tests/ExampParamVal1.v
@@ -24,4 +24,5 @@
 
         // Local Variables:
         // verilog-typedef-regexp: "_t$"
+        // verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
         // End:

--- a/tests/ExampParamVal2.v
+++ b/tests/ExampParamVal2.v
@@ -25,4 +25,5 @@
         // Local Variables:
         // verilog-typedef-regexp: "_t$"
         // verilog-auto-inst-param-value: t
+        // verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
         // End:

--- a/tests/align_decl_comments.sv
+++ b/tests/align_decl_comments.sv
@@ -84,3 +84,8 @@ logic [1:0] /* embedded comment should NOT get aligned */ t3;
  /* This multiline comment
       should NOT get aligned */
 endmodule
+
+
+// Local Variables:
+// verilog-align-typedef-words: ("user_type")
+// End:

--- a/tests/align_decl_comments_nil.sv
+++ b/tests/align_decl_comments_nil.sv
@@ -87,5 +87,6 @@ endmodule
 
 // Local Variables:
 // verilog-align-decl-expr-comments: nil
+// verilog-align-typedef-words: ("user_type")
 // End:
 

--- a/tests/align_decl_comments_spacing_0.sv
+++ b/tests/align_decl_comments_spacing_0.sv
@@ -87,5 +87,6 @@ endmodule
 
 // Local Variables:
 // verilog-align-comment-distance: 0
+// verilog-align-typedef-words: ("user_type")
 // End:
 

--- a/tests/align_decl_comments_spacing_10.sv
+++ b/tests/align_decl_comments_spacing_10.sv
@@ -87,5 +87,6 @@ endmodule
 
 // Local Variables:
 // verilog-align-comment-distance: 10
+// verilog-align-typedef-words: ("user_type")
 // End:
 

--- a/tests/align_declarations.v
+++ b/tests/align_declarations.v
@@ -1,0 +1,23 @@
+module foo (
+input logic in,
+output logic out,
+input custom_t my_type,
+input [3:0] byte_t my_word_array_packed,
+output other_t other_type_array_unpacked [3],
+input custom_e my_enum,
+output custom_s my_struct,
+custom_if my_if
+);
+
+custom_vif my_vif;
+logic sig1;
+logic sig2;
+custom_t my_type1;
+other_t other_type1;
+custom_if my_if1;
+
+endmodule
+
+// Local Variables:
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_\\(t\\|e\\|s\\|if\\|vif\\)\\>"
+// End:

--- a/tests/align_ports_custom_type.sv
+++ b/tests/align_ports_custom_type.sv
@@ -11,3 +11,6 @@ custom_type type3;
 
 endmodule
 
+// Local Variables:
+// verilog-align-typedef-words: ("custom_type")
+// End:

--- a/tests/align_verilog_typedef.sv
+++ b/tests/align_verilog_typedef.sv
@@ -1,0 +1,27 @@
+class test;
+
+virtual function void cmp_core
+(
+input bit [8:0] max_len,
+input bit mv,
+mv2, mv3,
+mv3,
+ref example_t algo_cfg,
+ref bit [17:0] orig_img [],
+ref bit [15:0] cmp_img [],
+example_t algo_cfg,
+example_e asdf,
+example_if asdf_if,
+example_vif asdf_if,
+example_t[2] algo_cfg,
+input bit recmp_en = 1'b0,
+output bit [17:0] re_pixel_output_tmp
+);
+
+endfunction
+
+endclass
+
+// Local Variables:
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_\\(t\\|e\\|s\\|if\\|vif\\)\\>"
+// End:

--- a/tests/autoinoutmodport_bourduas_type.v
+++ b/tests/autoinoutmodport_bourduas_type.v
@@ -27,5 +27,6 @@ interface autoinoutmodport_type_intf(input logic clk, input logic rst_n);
 endinterface
 
 // Local Variables:
-// verilog-typedef-regexp:"_t"
+// verilog-typedef-regexp:"_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/autoinst_bug373.v
+++ b/tests/autoinst_bug373.v
@@ -44,4 +44,5 @@ endmodule // top
 
 // Local Variables:
 // verilog-typedef-regexp: "_s$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_s\\>"
 // End:

--- a/tests/autoinst_casefold_hou.v
+++ b/tests/autoinst_casefold_hou.v
@@ -42,4 +42,5 @@ endmodule
 // verilog-case-fold:nil
 // verilog-library-directories:(".")
 // verilog-typedef-regexp:"^t[A-Z]"
+// verilog-align-typedef-words: ("tTest")
 // End:

--- a/tests/autoinst_ding.v
+++ b/tests/autoinst_ding.v
@@ -40,8 +40,8 @@ AA AA_U(/*AUTOINST*/);
 
 BB BB_U(/*AUTOINST*/);
 
+endmodule
+
 // Local Variables:
 // verilog-library-directories:(".")
 // End:
-
-endmodule

--- a/tests/autoinst_import.v
+++ b/tests/autoinst_import.v
@@ -24,4 +24,5 @@ endmodule
 // Local Variables:
 // verilog-library-directories:(".")
 // verilog-library-extensions:(".v" ".sv")
+// verilog-align-typedef-words: ("svi")
 // End:

--- a/tests/autoinst_interface.v
+++ b/tests/autoinst_interface.v
@@ -48,3 +48,8 @@ module top;
 				   .reset		(reset),
 				   .start		(start));
 endmodule
+
+
+// Local Variables:
+// verilog-align-typedef-words: ("my_svi")
+// End:

--- a/tests/autoinst_modport_param.v
+++ b/tests/autoinst_modport_param.v
@@ -35,4 +35,5 @@ endmodule
 // Local Variables:
 // verilog-library-directories:(".")
 // verilog-library-extensions:(".v" ".sv")
+// verilog-align-typedef-words: ("svi")
 // End:

--- a/tests/autoinst_mplist.sv
+++ b/tests/autoinst_mplist.sv
@@ -48,5 +48,6 @@ endmodule
  verilog-typedef-regexp:"_t$"
  verilog-library-directories:(".")
  verilog-library-extensions:(".sv")
+ verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_if\\>"
  End:
  */

--- a/tests/autoinst_mplist_child.sv
+++ b/tests/autoinst_mplist_child.sv
@@ -29,5 +29,6 @@ endmodule
  verilog-typedef-regexp:"_t$"
  verilog-library-directories:(".")
  verilog-library-extensions:(".sv")
+ verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_if\\>"
  End:
  */

--- a/tests/autoinst_param_2d.v
+++ b/tests/autoinst_param_2d.v
@@ -41,4 +41,5 @@ endmodule
 // Local Variables:
 // verilog-auto-inst-param-value:t
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/autoinst_param_type.v
+++ b/tests/autoinst_param_type.v
@@ -85,4 +85,5 @@ endmodule
 // verilog-typedef-regexp: "_[tT]$"
 // verilog-auto-inst-param-value:t
 // verilog-auto-inst-param-value-type:t
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_[tT]\\>"
 // End:

--- a/tests/autoinst_tennant.v
+++ b/tests/autoinst_tennant.v
@@ -98,6 +98,7 @@ endmodule // xx
 
 // Local Variables:
 // verilog-typedef-regexp:"_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // verilog-library-directories:("." )
 // verilog-library-extensions:(".v" ".sv" ".h" ".vr" ".vm")
 // End:

--- a/tests/autoinstparam_first.v
+++ b/tests/autoinstparam_first.v
@@ -3,7 +3,7 @@ module autoinstparam_first ();
    parameter BITSCHANGED;
    parameter BITSA;
    parameter type BITSB_t;
-   typedef [2:0] my_bitsb_t;
+   typedef reg [2:0] my_bitsb_t;
 
    /* autoinstparam_first_sub AUTO_TEMPLATE (
        .BITSA		(BITSCHANGED),

--- a/tests/autoinstparam_first_sub.v
+++ b/tests/autoinstparam_first_sub.v
@@ -18,4 +18,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/autowire_req_sw.v
+++ b/tests/autowire_req_sw.v
@@ -16,4 +16,5 @@ endmodule
 // Local Variables:
 // verilog-library-directories:(".")
 // verilog-typedef-regexp:"_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/indent_class_pkg_nil.sv
+++ b/tests/indent_class_pkg_nil.sv
@@ -2,6 +2,7 @@ package foo;
 
 typedef logic [7:0] byte_t;
 localparam byte_t ALL_ONES = 8'hFF;
+localparam byte_t [3:0] ALL_ZEROS = 32'h0;
 
 function foo3 (input int a);
 $display(a);
@@ -15,4 +16,5 @@ endpackage
 
 // Local Variables:
 // verilog-indent-class-inside-pkg: nil
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/indent_list_nil_align_ports_custom_type.sv
+++ b/tests/indent_list_nil_align_ports_custom_type.sv
@@ -14,4 +14,5 @@ endmodule
 
 // Local Variables:
 // verilog-indent-lists: nil
+// verilog-align-typedef-words: ("custom_type")
 // End:

--- a/tests/indent_list_nil_methods.sv
+++ b/tests/indent_list_nil_methods.sv
@@ -180,4 +180,5 @@ endclass
 
 // Local Variables:
 // verilog-indent-lists: nil
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/indent_reftype.v
+++ b/tests/indent_reftype.v
@@ -23,4 +23,5 @@ endclass
 
 // Local Variables:
 // verilog-typedef-regexp:"_t$" 
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/indent_struct.v
+++ b/tests/indent_struct.v
@@ -34,12 +34,18 @@ int a; // woops
 endmodule // foo
 
 module foo (
-input a;
-input c;
-output d;
+input a,
+input c,
+output d,
 );
 always @(a) g;
 
 
 
 endmodule // foo
+
+
+// Local Variables:
+// verilog-align-typedef-words: ("ahb_thingy" "xyzzy")
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
+// End:

--- a/tests/indent_unique_case-1.v
+++ b/tests/indent_unique_case-1.v
@@ -364,3 +364,6 @@ endmodule // xxx_xxxxxx
 
 
 
+// Local Variables:
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_e\\>"
+// End:

--- a/tests/v2k_typedef_yee.v
+++ b/tests/v2k_typedef_yee.v
@@ -79,4 +79,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/v2k_typedef_yee_sub1.v
+++ b/tests/v2k_typedef_yee_sub1.v
@@ -26,4 +26,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/v2k_typedef_yee_sub2.v
+++ b/tests/v2k_typedef_yee_sub2.v
@@ -32,4 +32,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests/vmm_regressions.sv
+++ b/tests/vmm_regressions.sv
@@ -249,3 +249,9 @@ class my_xactor extends vmm_xactor;
    `vmm_xactor_member_end(my_xactor)
    
 endclass: my_xactor
+
+
+// Local Variables:
+// verilog-align-typedef-regexp: "\\<\\(e\\|t\\|vmm\\)_[a-zA-Z_][a-zA-Z_0-9]*\\>"
+// End:
+

--- a/tests_ok/ExampParamVal1.v
+++ b/tests_ok/ExampParamVal1.v
@@ -2,7 +2,7 @@ module InstModule (o,i);
    parameter         WIDTH;
    input [WIDTH-1:0] i;
    parameter type    OUT_t;
-   output            OUT_t o;
+   output OUT_t      o;
 endmodule
 
 module vm_example1;
@@ -24,4 +24,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/ExampParamVal2.v
+++ b/tests_ok/ExampParamVal2.v
@@ -2,7 +2,7 @@ module InstModule (o,i);
    parameter         WIDTH;
    input [WIDTH-1:0] i;
    parameter type    OUT_t;
-   output            OUT_t o;
+   output OUT_t      o;
 endmodule
 
 module vm_example1;
@@ -25,4 +25,5 @@ endmodule
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
 // verilog-auto-inst-param-value: t
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/align_decl_comments.sv
+++ b/tests_ok/align_decl_comments.sv
@@ -29,8 +29,8 @@ module foo
    output logic done);                                // Added with respect to #922 to test alignment
    
    import my_pkg::*; // Added with respect to #922 to test alignment
-   logic [7:0] city_bus;                          // Added with respect to #922 to test alignment
-   var         user_type keep_type_also_way_left; //.  <==Keep-indent marker
+   logic [7:0]   city_bus;                // Added with respect to #922 to test alignment
+   var user_type keep_type_also_way_left; //.  <==Keep-indent marker
 endmodule
 
 
@@ -84,3 +84,8 @@ module foo
    /* This multiline comment
     should NOT get aligned */
 endmodule
+
+
+// Local Variables:
+// verilog-align-typedef-words: ("user_type")
+// End:

--- a/tests_ok/align_decl_comments_nil.sv
+++ b/tests_ok/align_decl_comments_nil.sv
@@ -29,8 +29,8 @@ module foo
    output logic done); // Added with respect to #922 to test alignment
    
    import my_pkg::*; // Added with respect to #922 to test alignment
-   logic [7:0] city_bus; // Added with respect to #922 to test alignment
-   var         user_type keep_type_also_way_left; //.  <==Keep-indent marker
+   logic [7:0]   city_bus; // Added with respect to #922 to test alignment
+   var user_type keep_type_also_way_left; //.  <==Keep-indent marker
 endmodule
 
 
@@ -87,5 +87,6 @@ endmodule
 
 // Local Variables:
 // verilog-align-decl-expr-comments: nil
+// verilog-align-typedef-words: ("user_type")
 // End:
 

--- a/tests_ok/align_decl_comments_spacing_0.sv
+++ b/tests_ok/align_decl_comments_spacing_0.sv
@@ -29,8 +29,8 @@ module foo
    output logic done);                               // Added with respect to #922 to test alignment
    
    import my_pkg::*; // Added with respect to #922 to test alignment
-   logic [7:0] city_bus;                         // Added with respect to #922 to test alignment
-   var         user_type keep_type_also_way_left;//.  <==Keep-indent marker
+   logic [7:0]   city_bus;               // Added with respect to #922 to test alignment
+   var user_type keep_type_also_way_left;//.  <==Keep-indent marker
 endmodule
 
 
@@ -87,5 +87,6 @@ endmodule
 
 // Local Variables:
 // verilog-align-comment-distance: 0
+// verilog-align-typedef-words: ("user_type")
 // End:
 

--- a/tests_ok/align_decl_comments_spacing_10.sv
+++ b/tests_ok/align_decl_comments_spacing_10.sv
@@ -29,8 +29,8 @@ module foo
    output logic done);                                         // Added with respect to #922 to test alignment
    
    import my_pkg::*; // Added with respect to #922 to test alignment
-   logic [7:0] city_bus;                                   // Added with respect to #922 to test alignment
-   var         user_type keep_type_also_way_left;          //.  <==Keep-indent marker
+   logic [7:0]   city_bus;                         // Added with respect to #922 to test alignment
+   var user_type keep_type_also_way_left;          //.  <==Keep-indent marker
 endmodule
 
 
@@ -87,5 +87,6 @@ endmodule
 
 // Local Variables:
 // verilog-align-comment-distance: 10
+// verilog-align-typedef-words: ("user_type")
 // End:
 

--- a/tests_ok/align_declarations.v
+++ b/tests_ok/align_declarations.v
@@ -1,0 +1,23 @@
+module foo (
+            input logic        in,
+            output logic       out,
+            input custom_t     my_type,
+            input [3:0] byte_t my_word_array_packed,
+            output other_t     other_type_array_unpacked [3],
+            input custom_e     my_enum,
+            output custom_s    my_struct,
+            custom_if          my_if
+            );
+   
+   custom_vif my_vif;
+   logic      sig1;
+   logic      sig2;
+   custom_t   my_type1;
+   other_t    other_type1;
+   custom_if  my_if1;
+   
+endmodule
+
+// Local Variables:
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_\\(t\\|e\\|s\\|if\\|vif\\)\\>"
+// End:

--- a/tests_ok/align_ports_custom_type.sv
+++ b/tests_ok/align_ports_custom_type.sv
@@ -1,8 +1,8 @@
 module foo (input logic [7:0] in1,
             input logic       in2,
-            custom_type type1,
+            custom_type       type1,
             output logic      out,
-            custom_type type2
+            custom_type       type2
             );
    
    logic [7:0] signal1;
@@ -11,3 +11,6 @@ module foo (input logic [7:0] in1,
    
 endmodule
 
+// Local Variables:
+// verilog-align-typedef-words: ("custom_type")
+// End:

--- a/tests_ok/align_verilog_typedef.sv
+++ b/tests_ok/align_verilog_typedef.sv
@@ -1,27 +1,27 @@
-class example_t;
-endclass // example_t
-
 class test;
-   typedef class example_t;
-   
-   // Breaks with (verilog-pretty-declarations)
    
    virtual function void cmp_core
      (
       input bit [8:0]   max_len,
       input bit         mv,
+                        mv2, mv3,
+                        mv3,
       ref example_t     algo_cfg,
       ref bit [17:0]    orig_img [],
       ref bit [15:0]    cmp_img [],
       example_t         algo_cfg,
+      example_e         asdf,
+      example_if        asdf_if,
+      example_vif       asdf_if,
+      example_t [2]     algo_cfg,
       input bit         recmp_en = 1'b0,
       output bit [17:0] re_pixel_output_tmp
       );
       
    endfunction
+   
 endclass
 
 // Local Variables:
-// verilog-typedef-regexp:"_t$"
-// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_\\(t\\|e\\|s\\|if\\|vif\\)\\>"
 // End:

--- a/tests_ok/autoinoutmodport_bourduas_type.v
+++ b/tests_ok/autoinoutmodport_bourduas_type.v
@@ -3,9 +3,9 @@
 module apl2c_connect(autoinoutmodport_type_intf ctl_i,
                      /*AUTOINOUTMODPORT("autoinoutmodport_type_intf",  "ctl_cb")*/
                      // Beginning of automatic in/out/inouts (from modport)
-                     input [4:0] inst,
-                     input       isel_t isel,
-                     input       replay
+                     input [4:0]  inst,
+                     input isel_t isel,
+                     input        replay
                      // End of automatics
                      );
    
@@ -23,8 +23,8 @@ interface autoinoutmodport_type_intf(input logic clk, input logic rst_n);
    import ap_defines::*;
    
    logic [4:0] inst;
-   isel_t       isel;
-   logic replay;
+   isel_t      isel;
+   logic       replay;
    
    clocking ctl_cb @(posedge clk);
       input inst;
@@ -37,5 +37,6 @@ interface autoinoutmodport_type_intf(input logic clk, input logic rst_n);
 endinterface
 
 // Local Variables:
-// verilog-typedef-regexp:"_t"
+// verilog-typedef-regexp:"_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/autoinst_bug373.v
+++ b/tests_ok/autoinst_bug373.v
@@ -4,11 +4,11 @@ typedef struct packed {
 } mystruct_s;
 
 module submod
-  (input logic       a_port,
-   input logic [4:0] b_bus,
-   input             mystruct_s single_struct_is_fine,
-   input             mystruct_s [2:0] array_of_struct_is_not,
-   output logic      status);
+  (input logic            a_port,
+   input logic [4:0]      b_bus,
+   input mystruct_s       single_struct_is_fine,
+   input mystruct_s [2:0] array_of_struct_is_not,
+   output logic           status);
    
    /*AUTOTIEOFF*/
    // Beginning of automatic tieoffs (for this module's unterminated outputs)
@@ -20,15 +20,15 @@ endmodule // submod
 module top;
    /*AUTOLOGIC*/
    // Beginning of automatic wires (for undeclared instantiated-module outputs)
-   logic status; // From submod0 of submod.v
+   logic            status;                 // From submod0 of submod.v
    // End of automatics
    
    /*AUTOREGINPUT*/
    // Beginning of automatic reg inputs (for undeclared instantiated-module inputs)
-   logic a_port; // To submod0 of submod.v
-   mystruct_s [2:0]     array_of_struct_is_not; // To submod0 of submod.v
-   logic [4:0] b_bus; // To submod0 of submod.v
-   mystruct_s           single_struct_is_fine;  // To submod0 of submod.v
+   logic            a_port;                 // To submod0 of submod.v
+   mystruct_s [2:0] array_of_struct_is_not; // To submod0 of submod.v
+   logic [4:0]      b_bus;                  // To submod0 of submod.v
+   mystruct_s       single_struct_is_fine;  // To submod0 of submod.v
    // End of automatics
    
    submod submod0
@@ -44,4 +44,5 @@ endmodule // top
 
 // Local Variables:
 // verilog-typedef-regexp: "_s$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_s\\>"
 // End:

--- a/tests_ok/autoinst_casefold_hou.v
+++ b/tests_ok/autoinst_casefold_hou.v
@@ -11,7 +11,7 @@ module test
    
    /*AUTOWIRE*/
    // Beginning of automatic wires (for undeclared instantiated-module outputs)
-   tTest                q;                      // From foo of foo.v
+   tTest      q; // From foo of foo.v
    // End of automatics
    
    /* foo AUTO_TEMPLATE (
@@ -31,10 +31,10 @@ endmodule
 
 module foo
   (
-   input       clk,
-   input       rst,
-   input [7:0] tm,
-   output      tTest q
+   input        clk,
+   input        rst,
+   input [7:0]  tm,
+   output tTest q
    );
 endmodule
 
@@ -42,4 +42,5 @@ endmodule
 // verilog-case-fold:nil
 // verilog-library-directories:(".")
 // verilog-typedef-regexp:"^t[A-Z]"
+// verilog-align-typedef-words: ("tTest")
 // End:

--- a/tests_ok/autoinst_ding.v
+++ b/tests_ok/autoinst_ding.v
@@ -81,8 +81,8 @@ module TOP(
            .mbist_done                  (mbist_done[8:0]),
            .mbist_fail                  (mbist_fail[8:0]));
    
-   // Local Variables:
-   // verilog-library-directories:(".")
-   // End:
-   
 endmodule
+
+// Local Variables:
+// verilog-library-directories:(".")
+// End:

--- a/tests_ok/autoinst_import.v
+++ b/tests_ok/autoinst_import.v
@@ -3,13 +3,13 @@
 module InstModule
   (input      clk,
    svi.master svi_modport,
-   svi svi_nomodport);
+   svi        svi_nomodport);
 endmodule // InstModule
 
 module InstModule1 import mdp_pkg::*;
    (input      clk,
     svi.master svi_modport,
-    svi svi_nomodport);
+    svi        svi_nomodport);
 endmodule
 
 module top;
@@ -34,4 +34,5 @@ endmodule
 // Local Variables:
 // verilog-library-directories:(".")
 // verilog-library-extensions:(".v" ".sv")
+// verilog-align-typedef-words: ("svi")
 // End:

--- a/tests_ok/autoinst_interface.v
+++ b/tests_ok/autoinst_interface.v
@@ -8,8 +8,8 @@ module autoinst_interface
    input logic        reset,
    input logic        start,
    my_svi.master      my_svi_port,
-   my_svi my_svi_noport,
-   my_svi my_svi_noport_upper_decl
+   my_svi             my_svi_noport,
+   my_svi             my_svi_noport_upper_decl
    // End of automatics
    );
 endmodule
@@ -22,8 +22,8 @@ module autoinst_interface
    output logic      start,
    input logic [7:0] count,
    my_svi.master     my_svi_port,
-   my_svi my_svi_noport,
-   my_svi my_svi_noport_upper_decl
+   my_svi            my_svi_noport,
+   my_svi            my_svi_noport_upper_decl
    // End of automatics
    );
 endmodule
@@ -48,3 +48,8 @@ module top;
                                    .reset               (reset),
                                    .start               (start));
 endmodule
+
+
+// Local Variables:
+// verilog-align-typedef-words: ("my_svi")
+// End:

--- a/tests_ok/autoinst_modport_param.v
+++ b/tests_ok/autoinst_modport_param.v
@@ -3,14 +3,14 @@
 module InstModule
   (svi.master svi_modport,
    input      clk,
-   svi svi_nomodport);
+   svi        svi_nomodport);
 endmodule
 
 module InstModule1 #
   (parameter TCQ = 100)
    (svi.master svi_modport,
     input      clk,
-    svi svi_nomodport);
+    svi        svi_nomodport);
 endmodule
 
 module top;
@@ -35,4 +35,5 @@ endmodule
 // Local Variables:
 // verilog-library-directories:(".")
 // verilog-library-extensions:(".v" ".sv")
+// verilog-align-typedef-words: ("svi")
 // End:

--- a/tests_ok/autoinst_mplist.sv
+++ b/tests_ok/autoinst_mplist.sv
@@ -17,7 +17,7 @@ module autoinst_mplist
    
    );
    
-   mbl_if                    msg_req_if;   // Some internal interface
+   mbl_if msg_req_if; // Some internal interface
    
    // --------------------------------------------------------------------------
    // Packages and Local Declarations
@@ -25,8 +25,8 @@ module autoinst_mplist
    
    /*AUTOLOGIC*/
    // Beginning of automatic wires (for undeclared instantiated-module outputs)
-   logic mem_rd_req; // From child of autoinst_mplist_child.v
-   logic msg_busy;   // From child of autoinst_mplist_child.v
+   logic  mem_rd_req; // From child of autoinst_mplist_child.v
+   logic  msg_busy;   // From child of autoinst_mplist_child.v
    // End of automatics
    
    
@@ -62,5 +62,6 @@ endmodule
  verilog-typedef-regexp:"_t$"
  verilog-library-directories:(".")
  verilog-library-extensions:(".sv")
+ verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_if\\>"
  End:
  */

--- a/tests_ok/autoinst_mplist_child.sv
+++ b/tests_ok/autoinst_mplist_child.sv
@@ -29,5 +29,6 @@ endmodule
  verilog-typedef-regexp:"_t$"
  verilog-library-directories:(".")
  verilog-library-extensions:(".sv")
+ verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_if\\>"
  End:
  */

--- a/tests_ok/autoinst_param_2d.v
+++ b/tests_ok/autoinst_param_2d.v
@@ -14,8 +14,8 @@ module a();
    
    input [XUM-1:0][YUM-1:0] my_data_xyz[ZUM];
    
-   input                    PARAMS0__t params0 [1:0];
-   input                    PARAMS1__t params1 [1:0];
+   input PARAMS0__t         params0 [1:0];
+   input PARAMS1__t         params1 [1:0];
 endmodule
 
 module top (/*AUTOARG*/
@@ -27,24 +27,24 @@ module top (/*AUTOARG*/
             );
    /*AUTOINPUT*/
    // Beginning of automatic inputs (from unused autoinst inputs)
-   input [TEST0_AUM-1:0] [TEST0_BUM-1:0] TEST0_my_data_ab;               // To a_0 of a.v
-   input [TEST0_AUM-1:0] [TEST0_BUM-1:0] TEST0_my_data_abv [TEST0_VUM];  // To a_0 of a.v
-   input [TEST0_AUM-1:0]                 TEST0_my_data_av [TEST0_VUM];   // To a_0 of a.v
-   input                                 TEST0_my_data_v [VUM];          // To a_0 of a.v
-   input                                 TEST0_my_data_vv [VUM][V2];     // To a_0 of a.v
-   input [XUM-1:0] [YUM-1:0]             TEST0_my_data_xyz [ZUM];        // To a_0 of a.v
-   input                                 TEST0_my_data_z;                // To a_0 of a.v
-   input                                 PARAMS0__t TEST0_params0 [1:0]; // To a_0 of a.v
-   input                                 PARAMS1__t TEST0_params1 [1:0]; // To a_0 of a.v
-   input [TEST1_AUM-1:0] [TEST1_BUM-1:0] TEST1_my_data_ab;               // To a_1 of a.v
-   input [TEST1_AUM-1:0] [TEST1_BUM-1:0] TEST1_my_data_abv [TEST1_VUM];  // To a_1 of a.v
-   input [TEST1_AUM-1:0]                 TEST1_my_data_av [TEST1_VUM];   // To a_1 of a.v
-   input                                 TEST1_my_data_v [VUM];          // To a_1 of a.v
-   input                                 TEST1_my_data_vv [VUM][V2];     // To a_1 of a.v
-   input [XUM-1:0] [YUM-1:0]             TEST1_my_data_xyz [ZUM];        // To a_1 of a.v
-   input                                 TEST1_my_data_z;                // To a_1 of a.v
-   input                                 PARAMS0__t TEST1_params0 [1:0]; // To a_1 of a.v
-   input                                 PARAMS1__t TEST1_params1 [1:0]; // To a_1 of a.v
+   input [TEST0_AUM-1:0] [TEST0_BUM-1:0] TEST0_my_data_ab;              // To a_0 of a.v
+   input [TEST0_AUM-1:0] [TEST0_BUM-1:0] TEST0_my_data_abv [TEST0_VUM]; // To a_0 of a.v
+   input [TEST0_AUM-1:0]                 TEST0_my_data_av [TEST0_VUM];  // To a_0 of a.v
+   input                                 TEST0_my_data_v [VUM];         // To a_0 of a.v
+   input                                 TEST0_my_data_vv [VUM][V2];    // To a_0 of a.v
+   input [XUM-1:0] [YUM-1:0]             TEST0_my_data_xyz [ZUM];       // To a_0 of a.v
+   input                                 TEST0_my_data_z;               // To a_0 of a.v
+   input PARAMS0__t                      TEST0_params0 [1:0];           // To a_0 of a.v
+   input PARAMS1__t                      TEST0_params1 [1:0];           // To a_0 of a.v
+   input [TEST1_AUM-1:0] [TEST1_BUM-1:0] TEST1_my_data_ab;              // To a_1 of a.v
+   input [TEST1_AUM-1:0] [TEST1_BUM-1:0] TEST1_my_data_abv [TEST1_VUM]; // To a_1 of a.v
+   input [TEST1_AUM-1:0]                 TEST1_my_data_av [TEST1_VUM];  // To a_1 of a.v
+   input                                 TEST1_my_data_v [VUM];         // To a_1 of a.v
+   input                                 TEST1_my_data_vv [VUM][V2];    // To a_1 of a.v
+   input [XUM-1:0] [YUM-1:0]             TEST1_my_data_xyz [ZUM];       // To a_1 of a.v
+   input                                 TEST1_my_data_z;               // To a_1 of a.v
+   input PARAMS0__t                      TEST1_params0 [1:0];           // To a_1 of a.v
+   input PARAMS1__t                      TEST1_params1 [1:0];           // To a_1 of a.v
    // End of automatics
    /*AUTOOUTPUT*/
    /*AUTOWIRE*/
@@ -97,4 +97,5 @@ endmodule
 // Local Variables:
 // verilog-auto-inst-param-value:t
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/autoinst_param_type.v
+++ b/tests_ok/autoinst_param_type.v
@@ -6,14 +6,14 @@ module ptype
   (
    /*AUTOINPUT*/
    // Beginning of automatic inputs (from unused autoinst inputs)
-   input              foo_t a,  // To b0 of ptype_buf.v, ...
+   input foo_t        a,  // To b0 of ptype_buf.v, ...
    // End of automatics
    
    /*AUTOOUTPUT*/
    // Beginning of automatic outputs (from unused autoinst outputs)
-   output             foo_t y0, // From b0 of ptype_buf.v
-   output logic [7:0] y1,       // From b1 of ptype_buf.v
-   output             TYPE_T y2 // From b2 of ptype_buf.v
+   output foo_t       y0, // From b0 of ptype_buf.v
+   output logic [7:0] y1, // From b1 of ptype_buf.v
+   output TYPE_T      y2  // From b2 of ptype_buf.v
    // End of automatics
    );
    
@@ -44,7 +44,7 @@ module ptype_buf
   #(parameter      WIDTH  = 1,
     parameter type TYPE_T = logic [WIDTH-1:0])
    (output TYPE_T y,
-    input  TYPE_T a);
+    input TYPE_T  a);
    assign y = a;
 endmodule
 
@@ -56,18 +56,18 @@ module InstModule (o,i);
    parameter         WIDTH;
    input [WIDTH-1:0] i;
    parameter type    OUT_t;
-   output            OUT_t o;
+   output OUT_t      o;
 endmodule
 
 module ExampInst;
    /*AUTOINPUT*/
    // Beginning of automatic inputs (from unused autoinst inputs)
-   input [9:0] i;         // To instName of InstModule.v
+   input [9:0]    i; // To instName of InstModule.v
    // End of automatics
    
    /*AUTOOUTPUT*/
    // Beginning of automatic outputs (from unused autoinst outputs)
-   output      upper_t o; // From instName of InstModule.v
+   output upper_t o; // From instName of InstModule.v
    // End of automatics
    
    InstModule
@@ -85,4 +85,5 @@ endmodule
 // verilog-typedef-regexp: "_[tT]$"
 // verilog-auto-inst-param-value:t
 // verilog-auto-inst-param-value-type:t
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_[tT]\\>"
 // End:

--- a/tests_ok/autoinst_tennant.v
+++ b/tests_ok/autoinst_tennant.v
@@ -65,19 +65,19 @@ endmodule // top
 module xx
   #(parameter X = 4,
     parameter Y = 1)
-   (input              clk,
-    input              rstb,
+   (input                   clk,
+    input                   rstb,
     
-    input [X-1:0][1:0] xc,
-    input [X-1:0]      xa,
-    input [X-1:0]      xb,
+    input [X-1:0][1:0]      xc,
+    input [X-1:0]           xa,
+    input [X-1:0]           xb,
     
-    input [X-1:0]      cb,
-    output             sometype_t [1:0] st,
+    input [X-1:0]           cb,
+    output sometype_t [1:0] st,
     
-    input [X*Y-1:0]    yb,
+    input [X*Y-1:0]         yb,
     
-    output             foobar
+    output                  foobar
     );
    
 endmodule // xx
@@ -85,25 +85,26 @@ endmodule // xx
 module yy
   #(parameter X = 4,
     parameter Y = 1)
-   (input               clk,
-    input               rstb,
+   (input                  clk,
+    input                  rstb,
     
-    output [X-1:0][1:0] xc,
-    output [X-1:0]      xa,
-    input [X-1:0]       xb,
+    output [X-1:0][1:0]    xc,
+    output [X-1:0]         xa,
+    input [X-1:0]          xb,
     
-    input [X-1:0]       cb,
-    input               sometype_t [1:0] st,
+    input [X-1:0]          cb,
+    input sometype_t [1:0] st,
     
-    output [X*Y-1:0]    yb,
+    output [X*Y-1:0]       yb,
     
-    output [4:0][2:0]   foobar2
+    output [4:0][2:0]      foobar2
     );
    
 endmodule // xx
 
 // Local Variables:
 // verilog-typedef-regexp:"_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // verilog-library-directories:("." )
 // verilog-library-extensions:(".v" ".sv" ".h" ".vr" ".vm")
 // End:

--- a/tests_ok/autoinstparam_first.v
+++ b/tests_ok/autoinstparam_first.v
@@ -1,9 +1,9 @@
 module autoinstparam_first ();
    
-   parameter      BITSCHANGED;
-   parameter      BITSA;
-   parameter type BITSB_t;
-   typedef [2:0] my_bitsb_t;
+   parameter         BITSCHANGED;
+   parameter         BITSA;
+   parameter type    BITSB_t;
+   typedef reg [2:0] my_bitsb_t;
    
    /* autoinstparam_first_sub AUTO_TEMPLATE (
     .BITSA              (BITSCHANGED),

--- a/tests_ok/autoinstparam_first_sub.v
+++ b/tests_ok/autoinstparam_first_sub.v
@@ -12,10 +12,11 @@ module autoinstparam_first_sub (/*AUTOARG*/
    parameter type  BITSB_t = bit; // See bug340
    
    inout [BITSA:0] a;
-   inout           BITSB_t b;
+   inout BITSB_t   b;
    
 endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/autowire_req_sw.v
+++ b/tests_ok/autowire_req_sw.v
@@ -2,7 +2,7 @@
 
 module autowire_req_sw
   (
-   input  reqcmd_t AReq,
+   input reqcmd_t  AReq,
    output reqcmd_t BReq
    /*AUTOINPUT*/
    );
@@ -16,4 +16,5 @@ endmodule
 // Local Variables:
 // verilog-library-directories:(".")
 // verilog-typedef-regexp:"_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/indent_2.v
+++ b/tests_ok/indent_2.v
@@ -1,15 +1,15 @@
 module foo(reg_input_signal_name,a,b,c,d,e);
    // foo bar
-   output            c; //this is a comment
+   output c; //this is a comment
    
    
-   reg               foo;
+   reg    foo;
    //a
    
    /*  jj
     KK */
-   reg               foo;
-   output reg        /*   */ signed d;
+   reg    foo;
+   output        reg  /*   */  signed        d;
    output reg signed e; /* so is this */
    
    reg [31:0]        blather;

--- a/tests_ok/indent_class_pkg_nil.sv
+++ b/tests_ok/indent_class_pkg_nil.sv
@@ -1,7 +1,8 @@
 package foo;
    
-   typedef logic [7:0] byte_t;
-   localparam          byte_t ALL_ONES = 8'hFF;
+   typedef logic [7:0]     byte_t;
+   localparam byte_t       ALL_ONES  = 8'hFF;
+   localparam byte_t [3:0] ALL_ZEROS = 32'h0;
    
    function foo3 (input int a);
       $display(a);
@@ -15,4 +16,5 @@ endpackage
 
 // Local Variables:
 // verilog-indent-class-inside-pkg: nil
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/indent_list_nil_align_ports_custom_type.sv
+++ b/tests_ok/indent_list_nil_align_ports_custom_type.sv
@@ -1,9 +1,9 @@
 module foo (
    input logic [7:0] in1,
    input logic       in2,
-   custom_type type1,
+   custom_type       type1,
    output logic      out,
-   custom_type type2
+   custom_type       type2
 );
    
    logic [7:0] signal1;
@@ -14,4 +14,5 @@ endmodule
 
 // Local Variables:
 // verilog-indent-lists: nil
+// verilog-align-typedef-words: ("custom_type")
 // End:

--- a/tests_ok/indent_list_nil_methods.sv
+++ b/tests_ok/indent_list_nil_methods.sv
@@ -3,10 +3,10 @@ class test;
    virtual function void func1 (
       input bit [8:0]   in1,
       input bit         in2,
-      ref example_t ref1,
+      ref example_t     ref1,
       ref bit [17:0]    ref2 [],
       ref bit [15:0]    ref3 [],
-      example_t ex1,
+      example_t         ex1,
       input bit         in3 = 1'b0,
       output bit [17:0] out1
    );
@@ -16,10 +16,10 @@ class test;
    virtual task task1 (
       input bit [8:0]   in1,
       input bit         in2,
-      ref example_t ref1,
+      ref example_t     ref1,
       ref bit [17:0]    ref2 [],
       ref bit [15:0]    ref3 [],
-      example_t ex1,
+      example_t         ex1,
       input bit         in3 = 1'b0,
       output bit [17:0] out1
    );
@@ -28,10 +28,10 @@ class test;
    
    virtual task task1 (input bit [8:0]   in1,
                        input bit         in2,
-                       ref example_t ref1,
+                       ref example_t     ref1,
                        ref bit [17:0]    ref2 [],
                        ref bit [15:0]    ref3 [],
-                       example_t ex1,
+                       example_t         ex1,
                        input bit         in3 = 1'b0,
                        output bit [17:0] out1
    );
@@ -41,7 +41,7 @@ class test;
    virtual task task1 (input bit [8:0]   in1, input bit in2, ref example_t ref1,
                        ref bit [17:0]    ref2 [],
                        ref bit [15:0]    ref3 [],
-                       example_t ex1,
+                       example_t         ex1,
                        input bit         in3 = 1'b0,
                        output bit [17:0] out1
    );
@@ -51,7 +51,7 @@ class test;
    virtual task task1 ( input bit [8:0]   in1, input bit in2, ref example_t ref1,
                         ref bit [17:0]    ref2 [],
                         ref bit [15:0]    ref3 [],
-                        example_t ex1,
+                        example_t         ex1,
                         input bit         in3 = 1'b0,
                         output bit [17:0] out1
    );
@@ -61,7 +61,7 @@ class test;
    virtual task task1 ( input bit [8:0]   in1, input bit in2, ref example_t ref1,
                         ref bit [17:0]    ref2 [],
                         ref bit [15:0]    ref3 [],
-                        example_t ex1,
+                        example_t         ex1,
                         input bit         in3 = 1'b0,
                         output bit [17:0] out1);
       out1 = {in1[7:0], in1[7:0]};
@@ -180,4 +180,5 @@ endclass
 
 // Local Variables:
 // verilog-indent-lists: nil
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/indent_struct.v
+++ b/tests_ok/indent_struct.v
@@ -4,21 +4,21 @@ module foo;
    a = c;
    
    typedef struct {
-      reg r;
-      ahb_op_t op; // Read, write, etc.
-      ahb_cycle_type_t cti; // Cycle type for bursts
-      ahb_incr_type_t incr; // Increment type (for bursts)
-      bit b;
-      reg r;
-      ahb_thingy a;
-      bit [31:2] addr;      // Starting address
-      bit [3:0]  byte_sel;  // Byte lane select
-      int        len;       // Length of transfer
-      bit [31:0] data[0:7]; // Write data
+      reg              r;
+      ahb_op_t         op;        // Read, write, etc.
+      ahb_cycle_type_t cti;       // Cycle type for bursts
+      ahb_incr_type_t  incr;      // Increment type (for bursts)
+      bit              b;
+      reg              r;
+      ahb_thingy       a;
+      bit [31:2]       addr;      // Starting address
+      bit [3:0]        byte_sel;  // Byte lane select
+      int              len;       // Length of transfer
+      bit [31:0]       data[0:7]; // Write data
    } ahb_req_t;
    
    struct {
-      reg f;
+      reg   f;
       xyzzy b;
    };
    struct packed {
@@ -34,12 +34,18 @@ module foo;
 endmodule // foo
 
 module foo (
-            input  a;
-            input  c;
-            output d;
+            input  a,
+            input  c,
+            output d,
             );
    always @(a) g;
    
    
    
 endmodule // foo
+
+
+// Local Variables:
+// verilog-align-typedef-words: ("ahb_thingy" "xyzzy")
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
+// End:

--- a/tests_ok/indent_unique_case-1.v
+++ b/tests_ok/indent_unique_case-1.v
@@ -364,3 +364,6 @@ endmodule // xxx_xxxxxx
 
 
 
+// Local Variables:
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_e\\>"
+// End:

--- a/tests_ok/v2k_typedef_yee.v
+++ b/tests_ok/v2k_typedef_yee.v
@@ -11,12 +11,12 @@ module v2k_typedef_yee
    //-----------------------
    // Output definitions
    //
-   output logic_t sub1_to_sub2_and_top; // Explicit output port
+   output logic_t   sub1_to_sub2_and_top; // Explicit output port
    
    /*AUTOOUTPUT*/
    // Beginning of automatic outputs (from unused autoinst outputs)
-   output logic_t ready;                // From itest_sub2 of v2k_typedef_yee_sub2.v
-   output pixel24_t sub2_out_pixel;     // From itest_sub2 of v2k_typedef_yee_sub2.v
+   output logic_t   ready;                // From itest_sub2 of v2k_typedef_yee_sub2.v
+   output pixel24_t sub2_out_pixel;       // From itest_sub2 of v2k_typedef_yee_sub2.v
    // End of automatics
    
    
@@ -25,10 +25,10 @@ module v2k_typedef_yee
    //
    /*AUTOINPUT*/
    // Beginning of automatic inputs (from unused autoinst inputs)
-   input  logic_t cp;                   // To itest_sub1 of v2k_typedef_yee_sub1.v, ...
-   input  logic_t pixel24_t pixel_ff;   // To itest_sub2 of v2k_typedef_yee_sub2.v
-   input  logic_t reset;                // To itest_sub1 of v2k_typedef_yee_sub1.v, ...
-   input  pixel24_t sub1_in_pixel;      // To itest_sub1 of v2k_typedef_yee_sub1.v
+   input logic_t    cp;                   // To itest_sub1 of v2k_typedef_yee_sub1.v, ...
+   input logic_t    pixel24_t pixel_ff;   // To itest_sub2 of v2k_typedef_yee_sub2.v
+   input logic_t    reset;                // To itest_sub1 of v2k_typedef_yee_sub1.v, ...
+   input pixel24_t  sub1_in_pixel;        // To itest_sub1 of v2k_typedef_yee_sub1.v
    // End of automatics
    
    
@@ -37,8 +37,8 @@ module v2k_typedef_yee
    //
    /*AUTOWIRE*/
    // Beginning of automatic wires (for undeclared instantiated-module outputs)
-   pixel24_t            sub1_out_pixel;         // From itest_sub1 of v2k_typedef_yee_sub1.v
-   logic_t              sub1_to_sub2;           // From itest_sub1 of v2k_typedef_yee_sub1.v
+   pixel24_t        sub1_out_pixel;       // From itest_sub1 of v2k_typedef_yee_sub1.v
+   logic_t          sub1_to_sub2;         // From itest_sub1 of v2k_typedef_yee_sub1.v
    // End of automatics
    
    
@@ -79,4 +79,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/v2k_typedef_yee_sub1.v
+++ b/tests_ok/v2k_typedef_yee_sub1.v
@@ -3,11 +3,11 @@
 module v2k_typedef_yee_sub1
   (
    output pixel24_t sub1_out_pixel,
-   input  pixel24_t sub1_in_pixel,
-   input  logic_t cp,
-   input  logic_t reset,
-   output logic_t sub1_to_sub2,
-   output logic_t sub1_to_sub2_and_top
+   input pixel24_t  sub1_in_pixel,
+   input logic_t    cp,
+   input logic_t    reset,
+   output logic_t   sub1_to_sub2,
+   output logic_t   sub1_to_sub2_and_top
    );
    
    
@@ -26,4 +26,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/v2k_typedef_yee_sub2.v
+++ b/tests_ok/v2k_typedef_yee_sub2.v
@@ -9,15 +9,15 @@ module v2k_typedef_yee_sub2
    );
    
    output pixel24_t sub2_out_pixel,
-   output logic_t ready,
-   input  pixel24_t sub2_in_pixel,
-   input  logic_t cp,
-   input  logic_t reset,
-   input  logic_t sub1_to_sub2,
-   input  logic_t sub1_to_sub2_and_top
-          
-          pixel24_t pixel_ff;
-   ff_t      sub1_to_sub2_ff;
+   output logic_t   ready,
+   input pixel24_t  sub2_in_pixel,
+   input logic_t    cp,
+   input logic_t    reset,
+   input logic_t    sub1_to_sub2,
+   input logic_t    sub1_to_sub2_and_top
+                    
+   pixel24_t        pixel_ff;
+   ff_t             sub1_to_sub2_ff;
    
    
    always_ff @(posedge cp) begin
@@ -32,4 +32,5 @@ endmodule
 
 // Local Variables:
 // verilog-typedef-regexp: "_t$"
+// verilog-align-typedef-regexp: "\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"
 // End:

--- a/tests_ok/vmm_regressions.sv
+++ b/tests_ok/vmm_regressions.sv
@@ -6,17 +6,17 @@ class my_xactor extends vmm_xactor;
    typedef class t_mydata;
    typedef class t_myclass;
    
-   int    myint;
-   int    myintarr[10];
-   int    myintda[];
-   int    myintaa_int[int];
-   int    myintaa_str[string];
+   int          myint;
+   int          myintarr[10];
+   int          myintda[];
+   int          myintaa_int[int];
+   int          myintaa_str[string];
    
-   string mystr;
-   string mystrarr[10];
-   string mystrda[];
-   string mystraa_int[int];
-   string mystraa_str[string];
+   string       mystr;
+   string       mystrarr[10];
+   string       mystrda[];
+   string       mystraa_int[int];
+   string       mystraa_str[string];
    
    e_myenum     myenum;
    e_myenum     myenumarr[10];
@@ -249,3 +249,9 @@ class my_xactor extends vmm_xactor;
    `vmm_xactor_member_end(my_xactor)
    
 endclass: my_xactor
+
+
+// Local Variables:
+// verilog-align-typedef-regexp: "\\<\\(e\\|t\\|vmm\\)_[a-zA-Z_][a-zA-Z_0-9]*\\>"
+// End:
+


### PR DESCRIPTION
Hi,

This PR adds support for alignment of user defined types when running `verilog-pretty-declarations`.

Related issues: #308 #386 #920

To perform alignment two variables are used:
- `verilog-typedef-regexp`: already existing variable, string that matches user types.
    - In order to carry out alignment it is required to match the Verilog identifier regexp, e.g. `"\\<[a-zA-Z_][a-zA-Z_0-9]*_t\\>"` or `(concat "\\<" verilog-identifier-re "_t\\>")`.
    - With a prefix/suffix format (e.g. `"_t$"`) alignment is not supported but AUTO functions still work as they did before.
- `verilog-typedef-words`: new variable, list of strings that match user types, e.g. `'("my_type" "custom_if" "my_enum")`. Defaults to `nil`.

Thanks!
