### PR TITLE
Fix bug in verilog-in-generate-region-p

### DIFF
--- a/tests/indent_generate_bug1404.sv
+++ b/tests/indent_generate_bug1404.sv
@@ -1,0 +1,27 @@
+// Bug 1404
+
+module test
+  #(paramweter integer OPT = 1
+     )
+    (input logic y,z;
+    );
+
+generate
+    if (OPT = 1) begin
+       always_comb begin
+          y = 1'b1;
+       end
+end else begin
+    always_comb begin
+       y = 1'b0;
+    end
+end
+
+    if (OPT = 1) begin
+       assign z = 1'b1;
+    end else begin
+       assign z = 1'b0;
+    end
+endgenerate
+
+endmodule // test

--- a/tests/indent_generate_case.v
+++ b/tests/indent_generate_case.v
@@ -1,6 +1,7 @@
 module indent_gen_case #(parameter P = 0)
 (input d, output reg q);
 
+generate
 case (P)
 0: always @(*)
 q = d;
@@ -20,5 +21,6 @@ q = d;
 end
 end
 endcase
+endgenerate
 
 endmodule

--- a/tests/indent_generate_for.v
+++ b/tests/indent_generate_for.v
@@ -2,6 +2,7 @@ module indent_gen_for #(parameter P = 1)
 (input d, output reg q);
 
 genvar i;
+generate
 for (i = 0; i < P; i += 1) begin
 always @(*) begin
 q = d;
@@ -12,5 +13,6 @@ for (i = 0; i < P; i += 1) begin
 always @(*)
 q = d;
 end
+endgenerate
 
 endmodule

--- a/tests/indent_generate_if.v
+++ b/tests/indent_generate_if.v
@@ -1,6 +1,7 @@
 module indent_gen_if #(parameter P = 0)
 (input d, output reg q);
 
+generate
 if (P == 0) begin
 always @(*)
 q = d;
@@ -20,5 +21,6 @@ else begin
 always @(*)
 q = d + 1'b1;
 end
+endgenerate
 
 endmodule

--- a/tests_ok/autoreset_inf_bug325.v
+++ b/tests_ok/autoreset_inf_bug325.v
@@ -6,4 +6,4 @@ module aaa();
       // note missing e-n-d
       always @(*) begin
       end
-      endmodule
+endmodule

--- a/tests_ok/indent_generate_bug1404.sv
+++ b/tests_ok/indent_generate_bug1404.sv
@@ -1,0 +1,27 @@
+// Bug 1404
+
+module test
+  #(paramweter integer OPT = 1
+    )
+   (input logic y,z;
+    );
+   
+   generate
+      if (OPT = 1) begin
+         always_comb begin
+            y = 1'b1;
+         end
+      end else begin
+         always_comb begin
+            y = 1'b0;
+         end
+      end
+      
+      if (OPT = 1) begin
+         assign z = 1'b1;
+      end else begin
+         assign z = 1'b0;
+      end
+   endgenerate
+   
+endmodule // test

--- a/tests_ok/indent_generate_case.v
+++ b/tests_ok/indent_generate_case.v
@@ -1,24 +1,26 @@
 module indent_gen_case #(parameter P = 0)
    (input d, output reg q);
    
-   case (P)
-     0: always @(*)
-       q = d;
-     
-     1: begin
-        always @(*)
+   generate
+      case (P)
+        0: always @(*)
           q = d;
-     end
-     
-     2: always @(*) begin
-        q = d;
-     end
-     
-     3: begin
-        always @(*) begin
+        
+        1: begin
+           always @(*)
+             q = d;
+        end
+        
+        2: always @(*) begin
            q = d;
         end
-     end
-   endcase
+        
+        3: begin
+           always @(*) begin
+              q = d;
+           end
+        end
+      endcase
+   endgenerate
    
 endmodule

--- a/tests_ok/indent_generate_for.v
+++ b/tests_ok/indent_generate_for.v
@@ -2,15 +2,17 @@ module indent_gen_for #(parameter P = 1)
    (input d, output reg q);
    
    genvar i;
-   for (i = 0; i < P; i += 1) begin
-      always @(*) begin
-         q = d;
+   generate
+      for (i = 0; i < P; i += 1) begin
+         always @(*) begin
+            q = d;
+         end
       end
-   end
-   
-   for (i = 0; i < P; i += 1) begin
-      always @(*)
-        q = d;
-   end
+      
+      for (i = 0; i < P; i += 1) begin
+         always @(*)
+           q = d;
+      end
+   endgenerate
    
 endmodule

--- a/tests_ok/indent_generate_if.v
+++ b/tests_ok/indent_generate_if.v
@@ -1,24 +1,26 @@
 module indent_gen_if #(parameter P = 0)
    (input d, output reg q);
    
-   if (P == 0) begin
-      always @(*)
-        q = d;
-   end
-   
-   if (P == 1) begin
-      always @(*) begin
-         q = d;
+   generate
+      if (P == 0) begin
+         always @(*)
+           q = d;
       end
-   end
-   
-   if (P == 1) begin
-      always @(*)
-        q = d;
-   end
-   else begin
-      always @(*)
-        q = d + 1'b1;
-   end
+      
+      if (P == 1) begin
+         always @(*) begin
+            q = d;
+         end
+      end
+      
+      if (P == 1) begin
+         always @(*)
+           q = d;
+      end
+      else begin
+         always @(*)
+           q = d + 1'b1;
+      end
+   endgenerate
    
 endmodule

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -4970,29 +4970,21 @@ More specifically, point @ in the line foo : @ begin"
   "Return true if in a generate region.
 More specifically, after a generate and before an endgenerate."
   (interactive)
-  (let ((nest 1))
-    (save-excursion
-      (catch 'done
-	(while (and
-		(/= nest 0)
-		(verilog-re-search-backward
-                "\\<\\(module\\)\\|\\(connectmodule\\)\\|\\(generate\\)\\|\\(endgenerate\\)\\|\\(if\\)\\|\\(case\\)\\|\\(for\\)\\>" nil 'move)
-		(cond
-		 ((match-end 1) ; module - we have crawled out
-		  (throw 'done 1))
-                ((match-end 2) ; connectmodule - we have crawled out
-                 (throw 'done 1))
-                ((match-end 3) ; generate
-		  (setq nest (1- nest)))
-                ((match-end 4) ; endgenerate
-                 (setq nest (1+ nest)))
-                ((match-end 5) ; if
-                 (setq nest (1- nest)))
-                ((match-end 6) ; case
-                 (setq nest (1- nest)))
-                ((match-end 7) ; for
-                 (setq nest (1- nest))))))))
-    (= nest 0) )) ; return nest
+  (let ((pos (point))
+        gen-beg-point gen-end-point)
+    (save-match-data
+      (save-excursion
+        (and (verilog-re-search-backward "\\<\\(generate\\)\\>" nil t)
+             (forward-word)
+             (setq gen-beg-point (point))
+             (verilog-forward-sexp)
+             (backward-word)
+             (setq gen-end-point (point)))))
+    (if (and gen-beg-point gen-end-point
+             (>= pos gen-beg-point)
+             (<= pos gen-end-point))
+        t
+      nil)))
 
 (defun verilog-in-fork-region-p ()
   "Return true if between a fork and join."


### PR DESCRIPTION
Hi,

This PR fixes a bug in the function `verilog-in-generate-region-p`. 
```verilog
module foo;

    some_if my_if;

    // If point is here, `verilog-in-generate-region-p' returns t:
    //  - Wrongly detects the if of the interface type as if it was a
    //    keyword due to regexp word boundaries not set properly

    generate begin : test_gen
        if (CONDITION == "TRUE") begin

            always @(posedge Clk) begin
                if (!Rst_n) begin
                    signal <= 0;
                end else begin
                    signal <= 1;
                end
            end

        end else if (CONDITION == "FALSE") begin

            always @(posedge Clk) begin
                if (!Rst_n) begin
                    signal <= 0;
                end else begin
                    signal <= 2;
                end
            end

        end else begin

            always @(posedge Clk) begin
                if (!Rst_n) begin
                    signal <= 0;
                end else begin
                    signal <= 3;
                end
            end

        end
    end : test_gen

    endgenerate

    // If point is here, `verilog-in-generate-region-p' returns t:
    //  - Wrongly detects the if of always blocks as if they were part
    //    of the 'generate if' condition


endmodule
```

It includes two commits:
- First commit adds missing `generate` keywords in related tests and adds one for #1404, which seems to have been fixed already
- Second commit rewrites the function `verilog-in-generate-region-p`, delegating the complexity of nesting to `verilog-forward-sexp`

Thanks!