### PR TITLE
verilog-auto-ignore-concat and struct.field fix

### DIFF
--- a/tests/auto_concat_ignore_nil.v
+++ b/tests/auto_concat_ignore_nil.v
@@ -1,0 +1,67 @@
+module xyz (/*AUTOARG*/
+   // Outputs
+   signal_f, signal_e, signal_d,
+   // Inputs
+   signal_c, signal_b, signal_a
+   );
+
+   // when verilog-auto-ignore-concat:nil, all signals are recongnized as IOs
+
+   /*AUTOINPUT*/
+   // Beginning of automatic inputs (from unused autoinst inputs)
+   input		signal_a;		// To u_abc of abc.v
+   input		signal_b;		// To u_abc of abc.v
+   input [1:0]		signal_c;		// To u_abc of abc.v
+   // End of automatics
+
+   /*AUTOOUTPUT*/
+   // Beginning of automatic outputs (from unused autoinst outputs)
+   output		signal_d;		// From u_abc of abc.v
+   output		signal_e;		// From u_abc of abc.v
+   output		signal_f;		// From u_abc of abc.v
+   // End of automatics
+
+   /*AUTOWIRE*/
+
+   /* abc AUTO_TEMPLATE
+     (
+      // Outputs
+      .signal_d				({signal_d}),
+      .signal_e				((signal_e)),
+      // Inputs
+      .signal_a				({signal_a}),
+      .signal_b				((signal_b)),
+    );*/
+
+   abc u_abc
+     (/*AUTOINST*/
+      // Outputs
+      .signal_d				({signal_d}),		 // Templated
+      .signal_e				((signal_e)),		 // Templated
+      .signal_f				(signal_f),
+      // Inputs
+      .signal_a				({signal_a}),		 // Templated
+      .signal_b				((signal_b)),		 // Templated
+      .signal_c				(signal_c[1:0]));
+
+endmodule // xyz
+
+module abc (/*AUTOARG*/
+   // Outputs
+   signal_d, signal_e, signal_f,
+   // Inputs
+   signal_a, signal_b, signal_c
+   );
+
+   input [1:0] signal_a;
+   input [1:0] signal_b;
+   input [1:0] signal_c;
+   output signal_d;
+   output signal_e;
+   output signal_f;
+
+endmodule // abc
+
+// Local Variables:
+// verilog-auto-ignore-concat: nil
+// End:

--- a/tests/auto_concat_ignore_t.v
+++ b/tests/auto_concat_ignore_t.v
@@ -1,0 +1,63 @@
+module xyz (/*AUTOARG*/
+   // Outputs
+   signal_f,
+   // Inputs
+   signal_c
+   );
+
+   // when verilog-auto-ignore-concat:t, only signal_c and signal_f are recongnized as IOs
+
+   /*AUTOINPUT*/
+   // Beginning of automatic inputs (from unused autoinst inputs)
+   input [1:0]		signal_c;		// To u_abc of abc.v
+   // End of automatics
+
+   /*AUTOOUTPUT*/
+   // Beginning of automatic outputs (from unused autoinst outputs)
+   output		signal_f;		// From u_abc of abc.v
+   // End of automatics
+
+   /*AUTOWIRE*/
+
+   /* abc AUTO_TEMPLATE
+     (
+      // Outputs
+      .signal_d				({signal_d}),
+      .signal_e				((signal_e)),
+      // Inputs
+      .signal_a				({signal_a}),
+      .signal_b				((signal_b)),
+    );*/
+
+   abc u_abc
+     (/*AUTOINST*/
+      // Outputs
+      .signal_d				({signal_d}),		 // Templated
+      .signal_e				((signal_e)),		 // Templated
+      .signal_f				(signal_f),
+      // Inputs
+      .signal_a				({signal_a}),		 // Templated
+      .signal_b				((signal_b)),		 // Templated
+      .signal_c				(signal_c[1:0]));
+
+endmodule // xyz
+
+module abc (/*AUTOARG*/
+   // Outputs
+   signal_d, signal_e, signal_f,
+   // Inputs
+   signal_a, signal_b, signal_c
+   );
+
+   input [1:0] signal_a;
+   input [1:0] signal_b;
+   input [1:0] signal_c;
+   output signal_d;
+   output signal_e;
+   output signal_f;
+
+endmodule // abc
+
+// Local Variables:
+// verilog-auto-ignore-concat: t
+// End:

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -9758,7 +9758,10 @@ Inserts the list of signals found, using submodi to look up each port."
 	;; We intentionally ignore (non-escaped) signals with .s in them
 	;; this prevents AUTOWIRE etc from noticing hierarchical sigs.
 	(when port
-          (cond ((looking-at "[^\n]*AUTONOHOOKUP"))
+          (cond ((and verilog-auto-ignore-concat
+                      (looking-at "[({]"))
+                 nil) ; {...} or (...) historically ignored with auto-ignore-concat
+		((looking-at "[^\n]*AUTONOHOOKUP"))
                 ((looking-at "\\([a-zA-Z_][a-zA-Z_0-9]*\\)\\s-*)")
 		 (verilog-read-sub-decls-sig
                   submoddecls par-values comment port
@@ -11439,7 +11442,7 @@ This repairs those mis-inserted by an AUTOARG."
           (while (string-match
                   (concat "\\([[({:*/<>+-]\\)"  ; - must be last
                           "(\\<\\([0-9A-Za-z_]+\\))"
-                          "\\([])}:*/<>+-]\\)")
+                          "\\([])}:*/<>.+-]\\)")
                   out)
             (setq out (replace-match "\\1\\2\\3" nil nil out)))
           (while (string-match
@@ -11534,7 +11537,8 @@ This repairs those mis-inserted by an AUTOARG."
 ;;(verilog-simplify-range-expression "[(TEST[1])-1:0]")
 ;;(verilog-simplify-range-expression "[1<<2:8>>2]")  ; [4:2]
 ;;(verilog-simplify-range-expression "[2*4/(4-2) +2+4 <<4 >>2]")
-;;(verilog-simplify-range-expression "[WIDTH*2/8-1:0]")
+;;(verilog-simplify-range-expression "[WIDTH*2/8-1:0]")  ; "[WIDTH*2/8-1:0]"
+;;(verilog-simplify-range-expression "[(FOO).size:0]")  ; "[FOO.size:0]"
 
 (defun verilog-clog2 (value)
   "Compute $clog2 - ceiling log2 of VALUE."


### PR DESCRIPTION
We appreciate your contributing to Verilog-Mode.

By contributing you agree this code will be licensed under the GNU Public License.

Please check your github name is set to your real name (click on your avatar icon in upper right, then "settings" then "Name".) This should match your system's ~/.gitconfig user name.
