### PR TITLE
Fix indentation of concurrent properties and sequences (#1836) (#1837)

### DIFF
--- a/tests/indent_assert_property.v
+++ b/tests/indent_assert_property.v
@@ -23,3 +23,17 @@ end
    always @(posedge clk) begin
    end
 endmodule
+
+// https://github.com/veripool/verilog-mode/issues/1836
+module tb1;
+ a: restrict property (1);
+   b: assume property (1);
+     c: assume property (1);
+       endmodule
+
+// https://github.com/veripool/verilog-mode/issues/1837
+module tb2;
+         a: cover sequence (1);
+     b: cover property (1);
+  c: cover property (1);
+endmodule

--- a/tests_ok/indent_assert_property.v
+++ b/tests_ok/indent_assert_property.v
@@ -23,3 +23,17 @@ module myassert(input        clk,
    always @(posedge clk) begin
    end
 endmodule
+
+// https://github.com/veripool/verilog-mode/issues/1836
+module tb1;
+   a: restrict property (1);
+   b: assume property (1);
+   c: assume property (1);
+endmodule
+
+// https://github.com/veripool/verilog-mode/issues/1837
+module tb2;
+   a: cover sequence (1);
+   b: cover property (1);
+   c: cover property (1);
+endmodule


### PR DESCRIPTION
…837)

* verilog-mode.el (verilog-property-re, verilog-beg-of-statement, verilog-calc-1): Concurrent SVA statement pattern-matching learns 'restrict property' and 'cover sequence' expression for proper indentation around those constructs. This addresses more patterns in IEEE 1800-2017's 'concurrent_sasertion_statement' grammar.

* tests{,_ok}/indent_assert_property.v: Add test cases from GitHub user 'pbing'

We appreciate your contributing to Verilog-Mode.

By contributing you agree this code will be licensed under the GNU Public License.

Please check your github name is set to your real name (click on your avatar icon in upper right, then "settings" then "Name".) This should match your system's ~/.gitconfig user name.
