### PR TITLE
Add autoinst_multidim_rename test and fix for issue #1848

### DIFF
--- a/tests/autoinst_multidim_rename.sv
+++ b/tests/autoinst_multidim_rename.sv
@@ -1,0 +1,44 @@
+module parent(/*AUTOARG*/);
+  input  [31:0][7:0] data_in;
+  output [4:0]       meta_out;
+  output [4:0]       meta_out_no_rename;
+  output [31:0][7:0] data_out;
+
+  /*AUTOWIRE*/
+
+  /* child1 AUTO_TEMPLATE (
+    .data_out                 (child1_out[][]),
+    .meta_out                 (child1_meta_out[]),
+  ); */
+  child1 U1 (
+    /*AUTOINST*/
+  )
+
+  /* child2 AUTO_TEMPLATE (
+    .data_in                 (child1_out[][]),
+    .meta_in                 (child1_meta_out[]),
+  ); */
+  child2 U2 (
+    /*AUTOINST*/
+  )
+
+endmodule
+
+module child1(/*AUTOARG*/);
+  input  [31:0][7:0] data_in;
+  output [31:0][7:0] data_out;
+  output [4:0]       meta_out;
+
+endmodule
+
+module child2(/*AUTOARG*/);
+  input  [31:0][7:0] data_in;
+  input  [4:0]       meta_in;
+  output [31:0][7:0] data_out;
+  output [4:0]       meta_out_no_rename;
+
+endmodule
+
+// Local Variables:
+// verilog-auto-inst-vector:nil
+// End:

--- a/tests_ok/autoinst_multidim_rename.sv
+++ b/tests_ok/autoinst_multidim_rename.sv
@@ -1,0 +1,72 @@
+module parent(/*AUTOARG*/
+              // Outputs
+              meta_out, meta_out_no_rename, data_out,
+              // Inputs
+              data_in
+              );
+   input [31:0][7:0]  data_in;
+   output [4:0]       meta_out;
+   output [4:0]       meta_out_no_rename;
+   output [31:0][7:0] data_out;
+   
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [4:0]         child1_meta_out; // From U1 of child1.v
+   wire [31:0] [7:0]  child1_out;      // From U1 of child1.v
+   // End of automatics
+   
+   /* child1 AUTO_TEMPLATE (
+    .data_out                 (child1_out[][]),
+    .meta_out                 (child1_meta_out[]),
+    ); */
+   child1 U1 (
+              /*AUTOINST*/
+              // Outputs
+              .data_out                 (child1_out/*[31:0][7:0]*/), // Templated
+              .meta_out                 (child1_meta_out[4:0]),  // Templated
+              // Inputs
+              .data_in                  (data_in/*[31:0][7:0]*/));
+   
+   /* child2 AUTO_TEMPLATE (
+    .data_in                 (child1_out[][]),
+    .meta_in                 (child1_meta_out[]),
+    ) */
+   child2 U2 (
+              /*AUTOINST*/
+              // Outputs
+              .data_out                 (data_out/*[31:0][7:0]*/),
+              .meta_out_no_rename       (meta_out_no_rename),
+              // Inputs
+              .data_in                  (child1_out/*[31:0][7:0]*/), // Templated
+              .meta_in                  (child1_meta_out[4:0]));         // Templated
+   
+endmodule
+
+module child1(/*AUTOARG*/
+              // Outputs
+              data_out, meta_out,
+              // Inputs
+              data_in
+              )
+  input [31:0][7:0]  data_in;
+   output [31:0][7:0] data_out;
+   output [4:0]       meta_out;
+   
+endmodule
+
+module child2(/*AUTOARG*/
+              // Outputs
+              data_out, meta_out_no_rename,
+              // Inputs
+              data_in, meta_in
+              );
+   input [31:0][7:0]  data_in;
+   input [4:0]        meta_in;
+   output [31:0][7:0] data_out;
+   output [4:0]       meta_out_no_rename;
+   
+endmodule
+
+// Local Variables:
+// verilog-auto-inst-vector:nil
+// End:

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -12257,6 +12257,8 @@ If PAR-VALUES replace final strings with these parameter values."
 	 (vl-mbits (if (verilog-sig-multidim port-st)
                        (verilog-sig-multidim-string port-st) ""))
    (vl-bits (or (verilog-sig-bits port-st) ""))
+   (auto-inst-vector nil)
+   (auto-inst-vector-tpl nil)
 	 (case-fold-search nil)
 	 (check-values par-values)
 	 tpl-net dflt-bits)


### PR DESCRIPTION
I had some more time to look into this, and I have both a test case and a fix for the issue. The summary of the changes are as follows:

- Set `vl-bits` without the logic that prevents displaying it in certain circumstances. This ensures it has the correct value when used in the multi-dim hint comment, as well as ensuring it will have the correct value if the user uses it directly in an `@"(...)"` expression.
- Added variable `auto-inst-vector` for the `auto-inst-vector` component that can be masked if `verilog-auto-inst-vector` isn't `t` or `'unsigned` and the net is signed, or if the port name matches one of the moddecls names (typically wires or outputs on the parent module) and the dimensions match. This preserves the original behavior expected by `verilog-auto-inst-vector`.
- In addition, if a port is connected to a different net (via an `AUTO_TEMPLATE`), then the name after renaming is used for the check (result is in `auto-inst-vector-tpl`). This ensures that `AUTOWIRE`/`AUTOINPUT`/`AUTOOUTPUT` works correctly for connections within a block, but it matches the expected behavior if the output port/wire already exists.

