### PR TITLE
fix apostrophe parser in auto wire  (#1854)

### DIFF
--- a/tests/autowire_apostrophe.sv
+++ b/tests/autowire_apostrophe.sv
@@ -1,0 +1,34 @@
+module test_port0
+(/*AUTOARG*/);
+    output [31:0] d[2];
+endmodule // test_port
+
+module test_port1
+(/*AUTOARG*/);
+   input [31:0] dd[2];
+endmodule // test_port1
+
+module top()
+/*AUTOWIRE*/  
+
+/*
+   test_port0  AUTO_TEMPLATE
+   (
+   .d\(.*\)         ('{d_1\1[],d_2\1[]}),
+   );
+*/   
+test_port0
+  u0(/*AUTOINST*/);
+   
+  /*
+   test_port1  AUTO_TEMPLATE
+   (
+   .d\(.*\)         ('{d_1\1[],d_2\1[]}),
+   );
+*/      
+
+test_port1
+  u1(/*AUTOINST*/);
+endmodule // top
+
+   

--- a/tests_ok/autowire_apostrophe.sv
+++ b/tests_ok/autowire_apostrophe.sv
@@ -1,0 +1,48 @@
+module test_port0
+  (/*AUTOARG*/
+   // Outputs
+   d
+   );
+   output [31:0] d[2];
+endmodule // test_port
+
+module test_port1
+  (/*AUTOARG*/
+   // Inputs
+   dd
+   );
+   input [31:0] dd[2];
+endmodule // test_port1
+
+module top()
+  /*AUTOWIRE*/
+  // Beginning of automatic wires (for undeclared instantiated-module outputs)
+  wire [31:0] d_1; // From u0 of test_port0.v
+   wire [31:0] d_2; // From u0 of test_port0.v
+   // End of automatics
+   
+   /*
+    test_port0  AUTO_TEMPLATE
+    (
+    .d\(.*\)         ('{d_1\1[],d_2\1[]}),
+    );
+    */
+   test_port0
+     u0(/*AUTOINST*/
+        // Outputs
+        .d                                      ('{d_1[31:0],d_2[31:0]})); // Templated
+   
+   /*
+    test_port1  AUTO_TEMPLATE
+    (
+    .d\(.*\)         ('{d_1\1[],d_2\1[]}),
+    );
+    */
+   
+   test_port1
+     u1(/*AUTOINST*/
+        // Inputs
+        .dd                             ('{d_1d[31:0],d_2d[31:0]})); // Templated
+endmodule // top
+
+

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -9680,7 +9680,7 @@ Return an array of [outputs inouts inputs wire reg assign const gparam intf]."
   (cond
    ;; {..., a, b} requires us to recurse on a,b
    ;; To support {#{},{#{a,b}} we'll just split everything on [{},]
-   ((string-match "^\\s-*{\\(.*\\)}\\s-*$" expr)
+   ((string-match "^\\s-*'?{\\(.*\\)}\\s-*$" expr)
     (let ((mlst (split-string (match-string 1 expr) "[{},]"))
           mstr)
       (while (setq mstr (pop mlst))


### PR DESCRIPTION
fix '{ } auto assign  