### PR TITLE
add AUTOLOCAL

### DIFF
--- a/tests/autoinst_autolocal.v
+++ b/tests/autoinst_autolocal.v
@@ -1,0 +1,24 @@
+module autoinst_autolocal(
+                          /*AUTOINPUT*/
+                          // Beginning of automatic inputs (from unused autoinst inputs)
+                          input i1 // To a2 of a2.v
+                          // End of automatics
+                          /*AUTOOUTPUT*/
+                          );
+   /* a2 AUTO_TEMPLATE (
+    .i1(i1),
+    .o1(o1), // AUTOLOCAL
+    ) */
+   a2 a2( /*AUTOINST*/
+          // Outputs
+          .o1                           (o1),                    // Templated AUTOLOCAL
+          // Inputs
+          .i1                           (i1));                   // Templated 
+endmodule
+
+module a2 (
+           input  i1,
+           output o1
+           );
+endmodule
+

--- a/tests_ok/autoinst_autolocal.v
+++ b/tests_ok/autoinst_autolocal.v
@@ -1,0 +1,24 @@
+module autoinst_autolocal(
+                          /*AUTOINPUT*/
+                          // Beginning of automatic inputs (from unused autoinst inputs)
+                          input i1 // To a2 of a2.v
+                          // End of automatics
+                          /*AUTOOUTPUT*/
+                          );
+   /* a2 AUTO_TEMPLATE (
+    .i1(i1),
+    .o1(o1), // AUTOLOCAL
+    ) */
+   a2 a2( /*AUTOINST*/
+          // Outputs
+          .o1                           (o1),                    // Templated AUTOLOCAL
+          // Inputs
+          .i1                           (i1));                   // Templated 
+endmodule
+
+module a2 (
+           input  i1,
+           output o1
+           );
+endmodule
+

--- a/tests_ok/autoinst_autolocal.v
+++ b/tests_ok/autoinst_autolocal.v
@@ -13,7 +13,7 @@ module autoinst_autolocal(
           // Outputs
           .o1                           (o1),                    // Templated AUTOLOCAL
           // Inputs
-          .i1                           (i1));                   // Templated 
+          .i1                           (i1));                   // Templated
 endmodule
 
 module a2 (

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -10223,8 +10223,7 @@ Returns REGEXP and list of ( (signal_name connection_name)... )."
                               (goto-char (match-end 0))
                               (cond
 				((looking-at "[^\n]*AUTONOHOOKUP") "AUTONOHOOKUP")
-				((looking-at "[^\n]*AUTOLOCAL") "AUTOLOCAL")
-				(t ""))))
+				((looking-at "[^\n]*AUTOLOCAL") "AUTOLOCAL"))))
 			   tpl-sig-list))
 	       (goto-char (match-end 0)))
               ;; Regexp form??
@@ -10245,8 +10244,7 @@ Returns REGEXP and list of ( (signal_name connection_name)... )."
                               (goto-char (match-end 0))
                               (cond
 				((looking-at "[^\n]*AUTONOHOOKUP") "AUTONOHOOKUP")
-				((looking-at "[^\n]*AUTOLOCAL") "AUTOLOCAL")
-				(t ""))))
+				((looking-at "[^\n]*AUTOLOCAL") "AUTOLOCAL"))))
 			   tpl-wild-list)))
 	      ((looking-at "[ \t\f]+")
 	       (goto-char (match-end 0)))
@@ -12401,7 +12399,7 @@ If PAR-VALUES replace final strings with these parameter values."
                    (t
                     (verilog-insert " // Templated")))
 	     ;; AUTONOHOOKUP
-             (verilog-insert (if (nth 4 tpl-ass) (concat " " (nth 4 tpl-ass))) "\n"))
+             (verilog-insert (if (nth 4 tpl-ass) (concat " " (nth 4 tpl-ass)) "") "\n"))
             (for-star
              (indent-to (+ (if (< verilog-auto-inst-column 48) 24 16)
                            verilog-auto-inst-column))


### PR DESCRIPTION
This is another way of applying ignore to outputs. 
We can ignore output ports by adding it to `verilog-auto-output-ignore-regexp`，but it takes time when there are many ports to ignore.
So, mark any output port by putting `AUTOLOCAL` in template, with this patch that port signal would be put into /*AUTOWIRE*/.
This operation is only meaningful for output port, as use user defined singal as input is working fine.

I find the method useful and convenient, so just pull it for further discussion.
