### PR TITLE
Fix incorrect function/task indentation when using `local` (#1904)

### DIFF
--- a/tests/indent_task_func_decl.sv
+++ b/tests/indent_task_func_decl.sv
@@ -40,19 +40,31 @@ class burst_drv extends vmm_xactor;
    protected virtual task pv_t();
       /**/
    endtask // pv_t
+   local virtual task lv_t();
+      /**/
+   endtask // lv_t
 
    protected task p_t();
       /* ACK*/
    endtask // p_t
+   local task l_t();
+      /* ACK*/
+   endtask // l_t
    virtual task v_t();
       /**/      
    endtask // v_t
    virtual protected task vp_t();
       /**/
    endtask // vp_t
+   virtual local task vl_t();
+      /**/
+   endtask // vl_t
    protected virtual task pv_t();
       /**/
    endtask // pv_t
+   local virtual task lv_t();
+      /**/
+   endtask // lv_t
    extern task e_t();
    extern virtual task ev_t();
    extern protected task ep_t();

--- a/tests_ok/indent_task_func_decl.sv
+++ b/tests_ok/indent_task_func_decl.sv
@@ -40,19 +40,31 @@ class burst_drv extends vmm_xactor;
    protected virtual task pv_t();
       /**/
    endtask // pv_t
+   local virtual task lv_t();
+      /**/
+   endtask // lv_t
    
    protected task p_t();
       /* ACK*/
    endtask // p_t
+   local task l_t();
+      /* ACK*/
+   endtask // l_t
    virtual task v_t();
       /**/
    endtask // v_t
    virtual protected task vp_t();
       /**/
    endtask // vp_t
+   virtual local task vl_t();
+      /**/
+   endtask // vl_t
    protected virtual task pv_t();
       /**/
    endtask // pv_t
+   local virtual task lv_t();
+      /**/
+   endtask // lv_t
    extern task e_t();
    extern virtual task ev_t();
    extern protected task ep_t();

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -2790,9 +2790,9 @@ find the errors."
 	   "\\|\\(\\<table\\>\\)"		;7
 	   "\\|\\(\\<specify\\>\\)"		;8
 	   "\\|\\(\\<function\\>\\)"		;9
-           "\\|\\(\\(?:\\<\\(?:virtual\\|protected\\|static\\)\\>\\s-+\\)*\\<function\\>\\)"  ;10
+           "\\|\\(\\(?:\\<\\(?:virtual\\|protected\\|local\\|static\\)\\>\\s-+\\)*\\<function\\>\\)"  ;10
            "\\|\\(\\<task\\>\\)"                ;11
-           "\\|\\(\\(?:\\<\\(?:virtual\\|protected\\|static\\)\\>\\s-+\\)*\\<task\\>\\)"      ;12
+           "\\|\\(\\(?:\\<\\(?:virtual\\|protected\\|local\\|static\\)\\>\\s-+\\)*\\<task\\>\\)"      ;12
            "\\|\\(\\<generate\\>\\)"            ;13
            "\\|\\(\\<covergroup\\>\\)"          ;14
            "\\|\\(\\(?:\\(?:\\<cover\\>\\s-+\\)\\|\\(?:\\<assert\\>\\s-+\\)\\)*\\<property\\>\\)" ;15
@@ -6406,7 +6406,7 @@ Jump from end to matching begin, from endcase to matching case, and so on."
 			"\\(\\<endcase\\>\\)\\|\\(\\<join\\(_any\\|_none\\)?\\>\\)" )))
      ((looking-at "\\<endtask\\>")
       ;; 2: Search back for matching task
-      (setq reg "\\(\\<task\\>\\)\\|\\(\\(\\<\\(virtual\\|protected\\|static\\)\\>\\s-+\\)+\\<task\\>\\)")
+      (setq reg "\\(\\<task\\>\\)\\|\\(\\(\\<\\(virtual\\|protected\\|local\\|static\\)\\>\\s-+\\)+\\<task\\>\\)")
       (setq nesting 'no))
      ((looking-at "\\<endcase\\>")
       (catch 'nesting
@@ -6430,7 +6430,7 @@ Jump from end to matching begin, from endcase to matching case, and so on."
       (setq reg "\\(\\<specify\\>\\)\\|\\(\\<endspecify\\>\\)" ))
      ((looking-at "\\<endfunction\\>")
       ;; 8: Search back for matching function
-      (setq reg "\\(\\<function\\>\\)\\|\\(\\(\\<\\(virtual\\|protected\\|static\\)\\>\\s-+\\)+\\<function\\>\\)")
+      (setq reg "\\(\\<function\\>\\)\\|\\(\\(\\<\\(virtual\\|protected\\|local\\|static\\)\\>\\s-+\\)+\\<function\\>\\)")
       (setq nesting 'no))
      ;;(setq reg "\\(\\<function\\>\\)\\|\\(\\<endfunction\\>\\)" ))
      ((looking-at "\\<endgenerate\\>")
@@ -7396,7 +7396,7 @@ Do not count named blocks or case-statements."
                (current-column))
               (;; 3) Inside a module/defun param list or function/task argument list
                (or (looking-at verilog-defun-level-re)
-                   (looking-at "\\(\\<\\(virtual\\|protected\\|static\\)\\>\\s-+\\)?\\(\\<task\\>\\|\\<function\\>\\)"))
+                   (looking-at "\\(\\<\\(virtual\\|protected\\|local\\|static\\)\\>\\s-+\\)?\\(\\<task\\>\\|\\<function\\>\\)"))
                (setq pos-arg-paren (save-excursion
                                      (goto-char start-pos)
                                      (verilog-backward-up-list 1)


### PR DESCRIPTION
Fix for issue #1904.
