### PR TITLE
Enhance AUTO_TEMPLATE for unpacked array connections and merging

### DIFF
--- a/tests/autoinst_tpl_array_index.v
+++ b/tests/autoinst_tpl_array_index.v
@@ -1,0 +1,61 @@
+module autoinst_tpl_array_index_sub
+  (
+   output [6:0] test2,
+   output       bitout
+   );
+endmodule
+
+// Instance index "[].[@]" connects one element of an unpacked array;
+// AUTOWIRE combines the connected indexes into one array declaration.
+
+module autoinst_tpl_array_index
+  ();
+   /*AUTOWIRE*/
+   /*
+    autoinst_tpl_array_index_sub AUTO_TEMPLATE
+    (
+    .test2 (abc[].[@]),
+    .bitout (sbit[].[@]),
+    );
+    */
+   autoinst_tpl_array_index_sub u_test2
+     (/*AUTOINST*/);
+   autoinst_tpl_array_index_sub u_test0
+     (/*AUTOINST*/);
+endmodule
+
+// Same element index twice warns "Couldn't Merge"
+
+module autoinst_tpl_array_index_dup
+  ();
+   /*AUTOWIRE*/
+   /*
+    autoinst_tpl_array_index_sub AUTO_TEMPLATE
+    (
+    .test2 (dup[].[1]),
+    .bitout (dupbit[].[@]),
+    );
+    */
+   autoinst_tpl_array_index_sub u_a1
+     (/*AUTOINST*/);
+   autoinst_tpl_array_index_sub u_a2
+     (/*AUTOINST*/);
+endmodule
+
+// Non-numeric index is not combined, first one wins
+
+module autoinst_tpl_array_index_nonnum
+  ();
+   /*AUTOWIRE*/
+   /*
+    autoinst_tpl_array_index_sub AUTO_TEMPLATE
+    (
+    .test2 (nn[].[IDX]),
+    .bitout (nnbit[].[@]),
+    );
+    */
+   autoinst_tpl_array_index_sub u_n1
+     (/*AUTOINST*/);
+   autoinst_tpl_array_index_sub u_n2
+     (/*AUTOINST*/);
+endmodule

--- a/tests/autologic_bracket.v
+++ b/tests/autologic_bracket.v
@@ -30,3 +30,6 @@ module top
 
 
 endmodule
+// Local Variables:
+// verilog-auto-inst-param-value:t
+// End:

--- a/tests/tpl_arr_edge.v
+++ b/tests/tpl_arr_edge.v
@@ -1,0 +1,183 @@
+// Sub module with various port types for unpacked-array AUTO_TEMPLATE tests.
+
+module tpl_arr_sub
+  (
+   output [15:0] data,
+   output [7:0]  addr,
+   output        flag,
+   output [3:0]  ctrl
+   );
+endmodule
+
+// ============================================================
+// Test: non-consecutive indexes produce separate declarations
+// ============================================================
+
+module tpl_arr_skip
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (s0[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_2
+     (/*AUTOINST*/);
+   tpl_arr_sub u_4
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: descending port range [15:0] + ascending unpacked [0:N]
+// ============================================================
+
+module tpl_arr_desc
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (d[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+   tpl_arr_sub u_2
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: multiple ports using [].[@] in the same template
+// ============================================================
+
+module tpl_arr_multi
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mdata[].[@]),
+    .flag (mflag[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: mergeable numeric index + non-numeric index in one template
+// ============================================================
+
+module tpl_arr_mixed
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mx[].[@]),       // numeric indexes → merged
+    .addr (mxaddr[].[IDX]), // non-numeric index → kept as-is
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: same signal name mapped to different hard-coded indexes;
+// each port gets its own declaration, not merged.
+// ============================================================
+
+module tpl_arr_gap
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (g[].[0]),
+    .addr (g[].[3]),
+    .ctrl (g[].[7]),
+    );
+    */
+   tpl_arr_sub u_a
+     (/*AUTOINST*/);
+   tpl_arr_sub u_b
+     (/*AUTOINST*/);
+   tpl_arr_sub u_c
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: single instance → single-element unpacked range [N:N]
+// ============================================================
+
+module tpl_arr_single
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (sing[].[@]),
+    );
+    */
+   tpl_arr_sub u_5
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: descending instance-name order still produces ascending
+// unpacked range (e.g. u_3, u_2, u_1 → [1:3])
+// ============================================================
+
+module tpl_arr_rev
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (rev[].[@]),
+    );
+    */
+   tpl_arr_sub u_3
+     (/*AUTOINST*/);
+   tpl_arr_sub u_2
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: overlapping unpacked ranges — [0:2] and [1:4] merge to
+// [0:4] via max/min; the overlap is not warned about.
+// This is a known limitation, not intended behaviour.
+// ============================================================
+
+module tpl_arr_overlap
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[0:2]),
+    );
+    */
+   tpl_arr_sub u_a
+     (/*AUTOINST*/);
+
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[1:4]),
+    );
+    */
+   tpl_arr_sub u_b
+     (/*AUTOINST*/);
+endmodule

--- a/tests/tpl_arr_edge.v
+++ b/tests/tpl_arr_edge.v
@@ -1,0 +1,303 @@
+// Sub module with various port types for unpacked-array AUTO_TEMPLATE tests.
+
+module tpl_arr_sub
+  (
+   output [15:0] data,
+   output [7:0]  addr,
+   output        flag,
+   output [3:0]  ctrl
+   );
+endmodule
+
+// Sub modules used to test mixed unpacked-array range handling.
+module tpl_arr_desc_numeric_sub
+  (
+   output [15:0] desc,
+   output [15:0] numeric
+   );
+endmodule
+
+module tpl_arr_symbolic_numeric_sub
+  (
+   output [15:0] symbolic,
+   output [15:0] numeric
+   );
+endmodule
+
+module tpl_arr_escaped_sub
+  (
+   output [15:0] data
+   );
+endmodule
+
+// ============================================================
+// Test: non-consecutive indexes produce one covering range
+// ============================================================
+
+module tpl_arr_skip
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (s0[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_2
+     (/*AUTOINST*/);
+   tpl_arr_sub u_4
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: descending port range [15:0] + ascending unpacked [0:N]
+// ============================================================
+
+module tpl_arr_desc
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (d[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+   tpl_arr_sub u_2
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: multiple ports using [].[@] in the same template
+// ============================================================
+
+module tpl_arr_multi
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mdata[].[@]),
+    .flag (mflag[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: mergeable numeric index + non-numeric index in one template
+// ============================================================
+
+module tpl_arr_mixed
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mx[].[@]),       // numeric indexes → merged
+    .addr (mxaddr[].[IDX]), // non-numeric index → kept as-is
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: same signal name mapped to different hard-coded indexes;
+// each port gets its own declaration, not merged.
+// ============================================================
+
+module tpl_arr_gap
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (g[].[0]),
+    .addr (g[].[3]),
+    .ctrl (g[].[7]),
+    );
+    */
+
+   tpl_arr_sub u_a
+     (/*AUTOINST*/);
+   tpl_arr_sub u_b
+     (/*AUTOINST*/);
+   tpl_arr_sub u_c
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: single instance → single-element unpacked range [N:N]
+// ============================================================
+
+module tpl_arr_single
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (sing[].[@]),
+    );
+    */
+   tpl_arr_sub u_5
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: descending instance-name order still produces ascending
+// unpacked range (e.g. u_3, u_2, u_1 → [1:3])
+// ============================================================
+
+module tpl_arr_rev
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (rev[].[@]),
+    );
+    */
+   tpl_arr_sub u_3
+     (/*AUTOINST*/);
+   tpl_arr_sub u_2
+     (/*AUTOINST*/);
+   tpl_arr_sub u_1
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: overlapping unpacked ranges [0:2] and [1:4] merge to
+// [0:4] and warn "Couldn't Merge".
+// ============================================================
+
+module tpl_arr_overlap
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[0:2]),
+    );
+    */
+   tpl_arr_sub u_a
+     (/*AUTOINST*/);
+
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[1:4]),
+    );
+    */
+   tpl_arr_sub u_b
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: signed unpacked ranges merge without expanding indexes
+// ============================================================
+
+module tpl_arr_signed
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (neg[].[-2:-1]),
+    );
+    */
+   tpl_arr_sub u_low
+     (/*AUTOINST*/);
+
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (neg[].[0:2]),
+    );
+    */
+   tpl_arr_sub u_high
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: a descending range wins over a numeric range for the
+// same signal, and AUTOWIRE reports that they could not merge.
+// ============================================================
+
+module tpl_arr_mixed_direction
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_desc_numeric_sub AUTO_TEMPLATE
+    (
+    .desc    (mixed[].[3:0]),
+    .numeric (mixed[].[@]),
+    );
+    */
+   tpl_arr_desc_numeric_sub u_0
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: a symbolic range wins over a numeric range for the
+// same signal, and AUTOWIRE reports that they could not merge.
+// ============================================================
+
+module tpl_arr_mixed_symbolic
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_symbolic_numeric_sub AUTO_TEMPLATE
+    (
+    .symbolic (sym[].[IDX]),
+    .numeric  (sym[].[@]),
+    );
+    */
+   tpl_arr_symbolic_numeric_sub u_0
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: a single negative index becomes a single-element range.
+// ============================================================
+
+module tpl_arr_signed_single
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (neg_one[].[-2]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/);
+endmodule
+
+// ============================================================
+// Test: escaped identifiers are retained while unpacked ranges
+// are recovered from an AUTO_TEMPLATE connection.
+// ============================================================
+
+module tpl_arr_escaped
+  ();
+   /*AUTOWIRE*/
+   /*
+    tpl_arr_escaped_sub AUTO_TEMPLATE
+    (
+    .data (\escaped_data [].[0:1]),
+    );
+    */
+   tpl_arr_escaped_sub u_0
+     (/*AUTOINST*/);
+endmodule

--- a/tests_ok/autoinst_tpl_array_index.v
+++ b/tests_ok/autoinst_tpl_array_index.v
@@ -1,0 +1,91 @@
+module autoinst_tpl_array_index_sub
+  (
+   output [6:0] test2,
+   output       bitout
+   );
+endmodule
+
+// Instance index "[].[@]" connects one element of an unpacked array;
+// AUTOWIRE combines the connected indexes into one array declaration.
+
+module autoinst_tpl_array_index
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [6:0] abc [0:2];  // From u_test2 of autoinst_tpl_array_index_sub.v, ...
+   wire       sbit [0:2]; // From u_test2 of autoinst_tpl_array_index_sub.v, ...
+   // End of automatics
+   /*
+    autoinst_tpl_array_index_sub AUTO_TEMPLATE
+    (
+    .test2 (abc[].[@]),
+    .bitout (sbit[].[@]),
+    );
+    */
+   autoinst_tpl_array_index_sub u_test2
+     (/*AUTOINST*/
+      // Outputs
+      .test2                            (abc[2]/*[6:0].[2]*/),   // Templated
+      .bitout                           (sbit[2]/*.[2]*/));      // Templated
+   autoinst_tpl_array_index_sub u_test0
+     (/*AUTOINST*/
+      // Outputs
+      .test2                            (abc[0]/*[6:0].[0]*/),   // Templated
+      .bitout                           (sbit[0]/*.[0]*/));      // Templated
+endmodule
+
+// Same element index twice warns "Couldn't Merge"
+
+module autoinst_tpl_array_index_dup
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [6:0] dup [1:1];    // From u_a1 of autoinst_tpl_array_index_sub.v, ..., Couldn't Merge
+   wire       dupbit [1:2]; // From u_a1 of autoinst_tpl_array_index_sub.v, ...
+   // End of automatics
+   /*
+    autoinst_tpl_array_index_sub AUTO_TEMPLATE
+    (
+    .test2 (dup[].[1]),
+    .bitout (dupbit[].[@]),
+    );
+    */
+   autoinst_tpl_array_index_sub u_a1
+     (/*AUTOINST*/
+      // Outputs
+      .test2                            (dup[1]/*[6:0].[1]*/),   // Templated
+      .bitout                           (dupbit[1]/*.[1]*/));    // Templated
+   autoinst_tpl_array_index_sub u_a2
+     (/*AUTOINST*/
+      // Outputs
+      .test2                            (dup[1]/*[6:0].[1]*/),   // Templated
+      .bitout                           (dupbit[2]/*.[2]*/));    // Templated
+endmodule
+
+// Non-numeric index is not combined, first one wins
+
+module autoinst_tpl_array_index_nonnum
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [6:0] nn [IDX];    // From u_n1 of autoinst_tpl_array_index_sub.v, ...
+   wire       nnbit [1:2]; // From u_n1 of autoinst_tpl_array_index_sub.v, ...
+   // End of automatics
+   /*
+    autoinst_tpl_array_index_sub AUTO_TEMPLATE
+    (
+    .test2 (nn[].[IDX]),
+    .bitout (nnbit[].[@]),
+    );
+    */
+   autoinst_tpl_array_index_sub u_n1
+     (/*AUTOINST*/
+      // Outputs
+      .test2                            (nn[IDX]/*[6:0].[IDX]*/), // Templated
+      .bitout                           (nnbit[1]/*.[1]*/));     // Templated
+   autoinst_tpl_array_index_sub u_n2
+     (/*AUTOINST*/
+      // Outputs
+      .test2                            (nn[IDX]/*[6:0].[IDX]*/), // Templated
+      .bitout                           (nnbit[2]/*.[2]*/));     // Templated
+endmodule

--- a/tests_ok/autologic_bracket.v
+++ b/tests_ok/autologic_bracket.v
@@ -30,3 +30,6 @@ module top
    
    
 endmodule
+// Local Variables:
+// verilog-auto-inst-param-value:t
+// End:

--- a/tests_ok/tpl_arr_edge.v
+++ b/tests_ok/tpl_arr_edge.v
@@ -1,0 +1,324 @@
+// Sub module with various port types for unpacked-array AUTO_TEMPLATE tests.
+
+module tpl_arr_sub
+  (
+   output [15:0] data,
+   output [7:0]  addr,
+   output        flag,
+   output [3:0]  ctrl
+   );
+endmodule
+
+// ============================================================
+// Test: non-consecutive indexes produce separate declarations
+// ============================================================
+
+module tpl_arr_skip
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;     // From u_0 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;     // From u_0 of tpl_arr_sub.v, ...
+   wire        flag;     // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] s0 [0:4]; // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (s0[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (s0[0]/*[15:0].[0]*/),   // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_2
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (s0[2]/*[15:0].[2]*/),   // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_4
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (s0[4]/*[15:0].[4]*/),   // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: descending port range [15:0] + ascending unpacked [0:N]
+// ============================================================
+
+module tpl_arr_desc
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;    // From u_0 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;    // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] d [0:2]; // From u_0 of tpl_arr_sub.v, ...
+   wire        flag;    // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (d[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (d[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (d[1]/*[15:0].[1]*/),    // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_2
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (d[2]/*[15:0].[2]*/),    // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: multiple ports using [].[@] in the same template
+// ============================================================
+
+module tpl_arr_multi
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;        // From u_0 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;        // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] mdata [0:1]; // From u_0 of tpl_arr_sub.v, ...
+   wire        mflag [0:1]; // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mdata[].[@]),
+    .flag (mflag[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mdata[0]/*[15:0].[0]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (mflag[0]/*.[0]*/),      // Templated
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mdata[1]/*[15:0].[1]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (mflag[1]/*.[1]*/),      // Templated
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: mergeable numeric index + non-numeric index in one template
+// ============================================================
+
+module tpl_arr_mixed
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [3:0]  ctrl;         // From u_0 of tpl_arr_sub.v, ...
+   wire        flag;         // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] mx [0:1];     // From u_0 of tpl_arr_sub.v, ...
+   wire [7:0]  mxaddr [IDX]; // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mx[].[@]),       // numeric indexes → merged
+    .addr (mxaddr[].[IDX]), // non-numeric index → kept as-is
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mx[0]/*[15:0].[0]*/),   // Templated
+      .addr                             (mxaddr[IDX]/*[7:0].[IDX]*/), // Templated
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mx[1]/*[15:0].[1]*/),   // Templated
+      .addr                             (mxaddr[IDX]/*[7:0].[IDX]*/), // Templated
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: same signal name mapped to different hard-coded indexes;
+// each port gets its own declaration, not merged.
+// ============================================================
+
+module tpl_arr_gap
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire        flag;    // From u_a of tpl_arr_sub.v, ...
+   wire [15:0] g [0:7]; // From u_a of tpl_arr_sub.v, ..., Couldn't Merge
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (g[].[0]),
+    .addr (g[].[3]),
+    .ctrl (g[].[7]),
+    );
+    */
+   tpl_arr_sub u_a
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (g[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (g[3]/*[7:0].[3]*/),     // Templated
+      .flag                             (flag),
+      .ctrl                             (g[7]/*[3:0].[7]*/));    // Templated
+   tpl_arr_sub u_b
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (g[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (g[3]/*[7:0].[3]*/),     // Templated
+      .flag                             (flag),
+      .ctrl                             (g[7]/*[3:0].[7]*/));    // Templated
+   tpl_arr_sub u_c
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (g[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (g[3]/*[7:0].[3]*/),     // Templated
+      .flag                             (flag),
+      .ctrl                             (g[7]/*[3:0].[7]*/));    // Templated
+endmodule
+
+// ============================================================
+// Test: single instance → single-element unpacked range [N:N]
+// ============================================================
+
+module tpl_arr_single
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;       // From u_5 of tpl_arr_sub.v
+   wire [3:0]  ctrl;       // From u_5 of tpl_arr_sub.v
+   wire        flag;       // From u_5 of tpl_arr_sub.v
+   wire [15:0] sing [5:5]; // From u_5 of tpl_arr_sub.v
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (sing[].[@]),
+    );
+    */
+   tpl_arr_sub u_5
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (sing[5]/*[15:0].[5]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: descending instance-name order still produces ascending
+// unpacked range (e.g. u_3, u_2, u_1 → [1:3])
+// ============================================================
+
+module tpl_arr_rev
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;      // From u_3 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;      // From u_3 of tpl_arr_sub.v, ...
+   wire        flag;      // From u_3 of tpl_arr_sub.v, ...
+   wire [15:0] rev [1:3]; // From u_3 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (rev[].[@]),
+    );
+    */
+   tpl_arr_sub u_3
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (rev[3]/*[15:0].[3]*/),  // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_2
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (rev[2]/*[15:0].[2]*/),  // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (rev[1]/*[15:0].[1]*/),  // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: overlapping unpacked ranges — [0:2] and [1:4] merge to
+// [0:4] via max/min; the overlap is not warned about.
+// This is a known limitation, not intended behaviour.
+// ============================================================
+
+module tpl_arr_overlap
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;     // From u_a of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;     // From u_a of tpl_arr_sub.v, ...
+   wire        flag;     // From u_a of tpl_arr_sub.v, ...
+   wire [15:0] ov [0:4]; // From u_a of tpl_arr_sub.v, ..., Couldn't Merge
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[0:2]),
+    );
+    */
+   tpl_arr_sub u_a
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (ov[0:2]/*[15:0].[0:2]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[1:4]),
+    );
+    */
+   tpl_arr_sub u_b
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (ov[1:4]/*[15:0].[1:4]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule

--- a/tests_ok/tpl_arr_edge.v
+++ b/tests_ok/tpl_arr_edge.v
@@ -1,0 +1,467 @@
+// Sub module with various port types for unpacked-array AUTO_TEMPLATE tests.
+
+module tpl_arr_sub
+  (
+   output [15:0] data,
+   output [7:0]  addr,
+   output        flag,
+   output [3:0]  ctrl
+   );
+endmodule
+
+// ============================================================
+// Test: non-consecutive indexes produce one covering range
+// ============================================================
+
+module tpl_arr_skip
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;     // From u_0 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;     // From u_0 of tpl_arr_sub.v, ...
+   wire        flag;     // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] s0 [0:4]; // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (s0[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (s0[0]/*[15:0].[0]*/),   // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_2
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (s0[2]/*[15:0].[2]*/),   // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_4
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (s0[4]/*[15:0].[4]*/),   // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: descending port range [15:0] + ascending unpacked [0:N]
+// ============================================================
+
+module tpl_arr_desc
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;    // From u_0 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;    // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] d [0:2]; // From u_0 of tpl_arr_sub.v, ...
+   wire        flag;    // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (d[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (d[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (d[1]/*[15:0].[1]*/),    // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_2
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (d[2]/*[15:0].[2]*/),    // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: multiple ports using [].[@] in the same template
+// ============================================================
+
+module tpl_arr_multi
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;        // From u_0 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;        // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] mdata [0:1]; // From u_0 of tpl_arr_sub.v, ...
+   wire        mflag [0:1]; // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mdata[].[@]),
+    .flag (mflag[].[@]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mdata[0]/*[15:0].[0]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (mflag[0]/*.[0]*/),      // Templated
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mdata[1]/*[15:0].[1]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (mflag[1]/*.[1]*/),      // Templated
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: mergeable numeric index + non-numeric index in one template
+// ============================================================
+
+module tpl_arr_mixed
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [3:0]  ctrl;         // From u_0 of tpl_arr_sub.v, ...
+   wire        flag;         // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] mx [0:1];     // From u_0 of tpl_arr_sub.v, ...
+   wire [7:0]  mxaddr [IDX]; // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (mx[].[@]),       // numeric indexes → merged
+    .addr (mxaddr[].[IDX]), // non-numeric index → kept as-is
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mx[0]/*[15:0].[0]*/),   // Templated
+      .addr                             (mxaddr[IDX]/*[7:0].[IDX]*/), // Templated
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (mx[1]/*[15:0].[1]*/),   // Templated
+      .addr                             (mxaddr[IDX]/*[7:0].[IDX]*/), // Templated
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: same signal name mapped to different hard-coded indexes;
+// each port gets its own declaration, not merged.
+// ============================================================
+
+module tpl_arr_gap
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire        flag;    // From u_a of tpl_arr_sub.v, ...
+   wire [15:0] g [0:7]; // From u_a of tpl_arr_sub.v, ..., Couldn't Merge
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (g[].[0]),
+    .addr (g[].[3]),
+    .ctrl (g[].[7]),
+    );
+    */
+   
+   tpl_arr_sub u_a
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (g[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (g[3]/*[7:0].[3]*/),     // Templated
+      .flag                             (flag),
+      .ctrl                             (g[7]/*[3:0].[7]*/));    // Templated
+   tpl_arr_sub u_b
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (g[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (g[3]/*[7:0].[3]*/),     // Templated
+      .flag                             (flag),
+      .ctrl                             (g[7]/*[3:0].[7]*/));    // Templated
+   tpl_arr_sub u_c
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (g[0]/*[15:0].[0]*/),    // Templated
+      .addr                             (g[3]/*[7:0].[3]*/),     // Templated
+      .flag                             (flag),
+      .ctrl                             (g[7]/*[3:0].[7]*/));    // Templated
+endmodule
+
+// ============================================================
+// Test: single instance → single-element unpacked range [N:N]
+// ============================================================
+
+module tpl_arr_single
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;       // From u_5 of tpl_arr_sub.v
+   wire [3:0]  ctrl;       // From u_5 of tpl_arr_sub.v
+   wire        flag;       // From u_5 of tpl_arr_sub.v
+   wire [15:0] sing [5:5]; // From u_5 of tpl_arr_sub.v
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (sing[].[@]),
+    );
+    */
+   tpl_arr_sub u_5
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (sing[5]/*[15:0].[5]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: descending instance-name order still produces ascending
+// unpacked range (e.g. u_3, u_2, u_1 → [1:3])
+// ============================================================
+
+module tpl_arr_rev
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;      // From u_3 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;      // From u_3 of tpl_arr_sub.v, ...
+   wire        flag;      // From u_3 of tpl_arr_sub.v, ...
+   wire [15:0] rev [1:3]; // From u_3 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (rev[].[@]),
+    );
+    */
+   tpl_arr_sub u_3
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (rev[3]/*[15:0].[3]*/),  // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_2
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (rev[2]/*[15:0].[2]*/),  // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   tpl_arr_sub u_1
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (rev[1]/*[15:0].[1]*/),  // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: overlapping unpacked ranges [0:2] and [1:4] merge to
+// [0:4] and warn "Couldn't Merge".
+// ============================================================
+
+module tpl_arr_overlap
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;     // From u_a of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;     // From u_a of tpl_arr_sub.v, ...
+   wire        flag;     // From u_a of tpl_arr_sub.v, ...
+   wire [15:0] ov [0:4]; // From u_a of tpl_arr_sub.v, ..., Couldn't Merge
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[0:2]),
+    );
+    */
+   tpl_arr_sub u_a
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (ov[0:2]/*[15:0].[0:2]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (ov[].[1:4]),
+    );
+    */
+   tpl_arr_sub u_b
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (ov[1:4]/*[15:0].[1:4]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: signed unpacked ranges merge without expanding indexes
+// ============================================================
+
+module tpl_arr_signed
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;       // From u_low of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;       // From u_low of tpl_arr_sub.v, ...
+   wire        flag;       // From u_low of tpl_arr_sub.v, ...
+   wire [15:0] neg [-2:2]; // From u_low of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (neg[].[-2:-1]),
+    );
+    */
+   tpl_arr_sub u_low
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (neg[-2:-1]/*[15:0].[-2:-1]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+   
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (neg[].[0:2]),
+    );
+    */
+   tpl_arr_sub u_high
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (neg[0:2]/*[15:0].[0:2]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: a descending range wins over a numeric range for the
+// same signal, and AUTOWIRE reports that they could not merge.
+// ============================================================
+
+module tpl_arr_mixed_direction
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [15:0] mixed [3:0]; // From u_0 of tpl_arr_desc_numeric_sub.v, ..., Couldn't Merge
+   // End of automatics
+   /*
+    tpl_arr_desc_numeric_sub AUTO_TEMPLATE
+    (
+    .desc    (mixed[].[3:0]),
+    .numeric (mixed[].[@]),
+    );
+    */
+   tpl_arr_desc_numeric_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .desc                             (mixed[3:0]/*[15:0].[3:0]*/), // Templated
+      .numeric                          (mixed[0]/*[15:0].[0]*/)); // Templated
+endmodule
+
+// ============================================================
+// Test: a symbolic range wins over a numeric range for the
+// same signal, and AUTOWIRE reports that they could not merge.
+// ============================================================
+
+module tpl_arr_mixed_symbolic
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [15:0] sym [IDX]; // From u_0 of tpl_arr_symbolic_numeric_sub.v, ..., Couldn't Merge
+   // End of automatics
+   /*
+    tpl_arr_symbolic_numeric_sub AUTO_TEMPLATE
+    (
+    .symbolic (sym[].[IDX]),
+    .numeric  (sym[].[@]),
+    );
+    */
+   tpl_arr_symbolic_numeric_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .symbolic                         (sym[IDX]/*[15:0].[IDX]*/), // Templated
+      .numeric                          (sym[0]/*[15:0].[0]*/)); // Templated
+endmodule
+
+// ============================================================
+// Test: a single negative index becomes a single-element range.
+// ============================================================
+
+module tpl_arr_signed_single
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [7:0]  addr;            // From u_0 of tpl_arr_sub.v, ...
+   wire [3:0]  ctrl;            // From u_0 of tpl_arr_sub.v, ...
+   wire        flag;            // From u_0 of tpl_arr_sub.v, ...
+   wire [15:0] neg_one [-2:-2]; // From u_0 of tpl_arr_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_sub AUTO_TEMPLATE
+    (
+    .data (neg_one[].[-2]),
+    );
+    */
+   tpl_arr_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (neg_one[-2]/*[15:0].[-2]*/), // Templated
+      .addr                             (addr[7:0]),
+      .flag                             (flag),
+      .ctrl                             (ctrl[3:0]));
+endmodule
+
+// ============================================================
+// Test: escaped identifiers are retained while unpacked ranges
+// are recovered from an AUTO_TEMPLATE connection.
+// ============================================================
+
+module tpl_arr_escaped
+  ();
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [15:0] \escaped_data  [0:1]; // From u_0 of tpl_arr_escaped_sub.v, ...
+   // End of automatics
+   /*
+    tpl_arr_escaped_sub AUTO_TEMPLATE
+    (
+    .data (\escaped_data [].[0:1]),
+    );
+    */
+   tpl_arr_escaped_sub u_0
+     (/*AUTOINST*/
+      // Outputs
+      .data                             (\escaped_data [0:1]/*[15:0].[0:1]*/)); // Templated
+endmodule

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -13264,10 +13264,7 @@ Limitations:
   in AUTO_TEMPLATEs.
 
   This does NOT work on memories or SystemVerilog .name connections,
-  declare those yourself.  However, unpacked arrays connected
-  element-by-element with an AUTO_TEMPLATE \"[].[index]\" connection
-  (see `verilog-auto-inst') are declared, combining the connected
-  indexes into one ascending range.
+  declare those yourself.  
 
   Verilog mode will add \"Couldn't Merge\" comments to signals it cannot
   determine how to bus together.  This occurs when you have ports with

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -12767,9 +12767,7 @@ Multiple Module Templates:
   Note the @ character was replaced with the 2 from \"ms2m\".
 
   A connection of \"[].[@]\" connects one element of an unpacked array.
-  The \"[]\" port range is placed into a comment so the connection stays
-  legal Verilog, and AUTOWIRE will declare the net as an unpacked array
-  spanning all connected indexes:
+  AUTOWIRE will declare the net as an unpacked array spanning all connected indexes:
 
         /* InstModule AUTO_TEMPLATE (
                 .ptl_mapvalidx          (ptl_mapvalid[].[@]),

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -9005,11 +9005,11 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
   (let (combo
         buswarn
 	out-list
-	sig highbit lowbit mem		; Temp information about current signal
+        sig highbit lowbit mem  ; Temp information about current signal
 	sv-name sv-highbit sv-lowbit	; Details about signal we are forming
 	sv-comment sv-memory sv-enum sv-signed sv-type sv-multidim sv-busstring
 	sv-modport
-	sv-mem-low sv-mem-high	; Bounds of mergeable unpacked numeric ranges
+        sv-mem-low sv-mem-high  ; Bounds of mergeable unpacked numeric ranges
 	bus)
     ;; Shove signals so duplicated signals will be adjacent
     (setq in-list (sort in-list #'verilog-signals-sort-compare))
@@ -9021,9 +9021,9 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 	      sv-highbit nil
 	      sv-busstring nil
 	      sv-comment (verilog-sig-comment sig)
-	      sv-memory  nil
-	      sv-mem-low nil
-	      sv-mem-high nil
+              sv-memory nil
+              sv-mem-low nil
+              sv-mem-high nil
 	      sv-enum    (verilog-sig-enum sig)
 	      sv-signed  (verilog-sig-signed sig)
 	      sv-type    (verilog-sig-type sig)
@@ -9054,24 +9054,24 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
       ;; Extract unpacked-array details
       (setq mem (verilog-sig-memory sig))
       (cond ((and mem
-		  (string-match "^\\[\\([+-]?[0-9]+\\):\\([+-]?[0-9]+\\)\\]$" mem)
-		  (<= (string-to-number (match-string 1 mem))
-		      (string-to-number (match-string 2 mem))))
-	     ;; Merge ascending numeric ranges without expanding every
-	     ;; index.  Overlapping or duplicate ranges merge silently,
-	     ;; matching the packed-bit merge above.
-	     ;; Descending ranges are left alone so existing declarations
-	     ;; keep their direction.
-	     (let ((lo (string-to-number (match-string 1 mem)))
-		   (hi (string-to-number (match-string 2 mem))))
-	       (when sv-memory  ; Mixed with an unmergeable form
-		 (setq buswarn ", Couldn't Merge"))
-	       (setq sv-mem-low (if sv-mem-low (min lo sv-mem-low) lo)
-		     sv-mem-high (if sv-mem-high (max hi sv-mem-high) hi))))
-	    (mem
-	     (when sv-mem-low  ; Mixed with a mergeable numeric range
-	       (setq buswarn ", Couldn't Merge"))
-	     (setq sv-memory (or sv-memory mem))))
+                  (string-match "^\\[\\([+-]?[0-9]+\\):\\([+-]?[0-9]+\\)\\]$" mem)
+                  (<= (string-to-number (match-string 1 mem))
+                      (string-to-number (match-string 2 mem))))
+             ;; Merge ascending numeric ranges without expanding every
+             ;; index.  Overlapping or duplicate ranges merge silently,
+             ;; matching the packed-bit merge above.
+             ;; Descending ranges are left alone so existing declarations
+             ;; keep their direction.
+             (let ((lo (string-to-number (match-string 1 mem)))
+                   (hi (string-to-number (match-string 2 mem))))
+               (when sv-memory  ; Mixed with an unmergeable form
+                 (setq buswarn ", Couldn't Merge"))
+               (setq sv-mem-low (if sv-mem-low (min lo sv-mem-low) lo)
+                     sv-mem-high (if sv-mem-high (max hi sv-mem-high) hi))))
+            (mem
+             (when sv-mem-low  ; Mixed with a mergeable numeric range
+               (setq buswarn ", Couldn't Merge"))
+             (setq sv-memory (or sv-memory mem))))
       ;; Peek ahead to next signal
       (setq in-list (cdr in-list))
       (setq sig (car in-list))
@@ -9085,7 +9085,7 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 			  sv-name bus))
 	       (setq buswarn ", Couldn't Merge"))
 	     (if (verilog-sig-comment sig) (setq combo ", ..."))
-	     (setq sv-enum   (or sv-enum   (verilog-sig-enum sig))
+             (setq sv-enum   (or sv-enum   (verilog-sig-enum sig))
 		   sv-signed (or sv-signed (verilog-sig-signed sig))
                    sv-type   (or sv-type   (verilog-sig-type sig))
                    sv-multidim (or sv-multidim (verilog-sig-multidim sig))
@@ -9101,18 +9101,18 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 				  (concat "[" (int-to-string sv-highbit) ":"
 					  (int-to-string sv-lowbit) "]")))
 			  (concat sv-comment combo buswarn)
-			  (cond
-			   ;; If any range was not safely mergeable, retain that
-			   ;; original unpacked declaration
-			   (sv-memory sv-memory)
-			   (sv-mem-low
-			    ;; Combined unpacked index span, ascending.
-			    (concat "["
-				    (int-to-string sv-mem-low)
-				    ":"
-				    (int-to-string sv-mem-high)
-				    "]")))
-			  sv-enum sv-signed sv-type sv-multidim sv-modport)
+                          (cond
+                           ;; If any range was not safely mergeable, retain that
+                           ;; original unpacked declaration
+                           (sv-memory sv-memory)
+                           (sv-mem-low
+                            ;; Combined unpacked index span, ascending.
+                            (concat "["
+                                    (int-to-string sv-mem-low)
+                                    ":"
+                                    (int-to-string sv-mem-high)
+                                    "]")))
+                          sv-enum sv-signed sv-type sv-multidim sv-modport)
 			 out-list)
 		   sv-name nil))))
     ;;
@@ -9723,14 +9723,14 @@ Return an array of [outputs inouts inputs wire reg assign const gparam intf]."
   ;; as an unpacked range below (single-element, mergeable by
   ;; `verilog-signals-combine-bus'); non-numeric indexes keep ".[index]".
   (when (string-match
-	 "^\\s-*\\(\\(?:[a-zA-Z_][a-zA-Z_0-9]*\\|\\\\[^ \t\n\f]+\\s-\\)\\)\\s-*\\[\\([^][]+\\)\\]\\s-*/\\*\\(\\(?:\\[[^][]+\\]\\)*\\)\\.\\[[^][]+\\]\\*/\\s-*$"
-	 expr)
+         "^\\s-*\\(\\(?:[a-zA-Z_][a-zA-Z_0-9]*\\|\\\\[^ \t\n\f]+\\s-\\)\\)\\s-*\\[\\([^][]+\\)\\]\\s-*/\\*\\(\\(?:\\[[^][]+\\]\\)*\\)\\.\\[[^][]+\\]\\*/\\s-*$"
+         expr)
     (let ((idx (match-string 2 expr)))
       (setq expr (concat (match-string 1 expr)
-			 (match-string 3 expr)
-			 ".[" idx
-			 (if (string-match "^[+-]?[0-9]+$" idx) (concat ":" idx) "")
-			 "]"))))
+                         (match-string 3 expr)
+                         ".[" idx
+                         (if (string-match "^[+-]?[0-9]+$" idx) (concat ":" idx) "")
+                         "]"))))
   ;; Replace special /*[....]*/ comments inserted by verilog-auto-inst-port
   (setq expr (verilog-string-replace-matches
               "/\\*\\(\\.?\\[\\([^*]+\\|[*][^/]\\)+\\]\\)\\*/" "\\1" nil nil expr))
@@ -12430,16 +12430,16 @@ If PAR-VALUES replace final strings with these parameter values."
       ;; e.g. "sig[].[2]" becomes "sig[2]/*[6:0].[2]*/".  AUTOWIRE etc
       ;; parse the comment back, see `verilog-read-sub-decls-expr'.
       (while (string-match "\\[\\]\\.\\(\\[[^][]+\\]\\)" tpl-net)
-	(setq tpl-net (replace-match
-		       (concat (match-string 1 tpl-net)
-			       "/*" vl-mbits vl-bits
-			       "." (match-string 1 tpl-net) "*/")
-		       t t tpl-net)))
+        (setq tpl-net (replace-match
+                       (concat (match-string 1 tpl-net)
+                               "/*" vl-mbits vl-bits
+                               "." (match-string 1 tpl-net) "*/")
+                       t t tpl-net)))
       ;; "[].[]" is left when "[].[@]" is used on an instance whose name
       ;; gives no @ value; catch it rather than emit a nonsense connection.
       (when (string-match "\\[\\]\\.\\[\\]" tpl-net)
-	(verilog-warn-error "%s: AUTO_TEMPLATE `%s' expanded to an empty [].[] index; instance name has no value for @"
-			    (verilog-point-text) tpl-net))
+        (verilog-warn-error "%s: AUTO_TEMPLATE `%s' expanded to an empty [].[] index; instance name has no value for @"
+                            (verilog-point-text) tpl-net))
       (setq tpl-net (verilog-string-replace-matches "\\[\\]\\[\\]" dflt-bits nil nil tpl-net))
       (setq tpl-net (verilog-string-replace-matches "\\[\\]" auto-inst-vector-tpl nil nil tpl-net)))
     ;; Insert it
@@ -12751,9 +12751,9 @@ Multiple Module Templates:
   For example:
 
         /* InstModule AUTO_TEMPLATE (
-                .ptl_mapvalidx          (ptl_mapvalid[@]),
-                .ptl_mapvalidp1x        (ptl_mapvalid[@\"(% (+ 1 @) 4)\"]),
-                );
+            .ptl_mapvalidx      (ptl_mapvalid[@]),
+            .ptl_mapvalidp1x    (ptl_mapvalid[@\"(% (+ 1 @) 4)\"]),
+            );
         */
         InstModule ms2m (/*AUTOINST*/);
 
@@ -12761,17 +12761,18 @@ Multiple Module Templates:
 
         InstModule ms2m (/*AUTOINST*/
             // Outputs
-            .ptl_mapvalidx              (ptl_mapvalid[2]),
-            .ptl_mapvalidp1x            (ptl_mapvalid[3]));
+            .ptl_mapvalidx      (ptl_mapvalid[2]),
+            .ptl_mapvalidp1x    (ptl_mapvalid[3]));
 
   Note the @ character was replaced with the 2 from \"ms2m\".
 
-  A connection of \"[].[@]\" connects one element of an unpacked array.
-  AUTOWIRE will declare the net as an unpacked array spanning all connected indexes:
+  A connection of \"[].[@]\" connects one element of an unpacked
+  array.  AUTOWIRE will declare the net as an unpacked array
+  spanning all connected indexes:
 
         /* InstModule AUTO_TEMPLATE (
-                .ptl_mapvalidx          (ptl_mapvalid[].[@]),
-                );
+            .ptl_mapvalidx      (ptl_mapvalid[].[@]),
+            );
         */
         InstModule ms2m (/*AUTOINST*/);
         InstModule ms0m (/*AUTOINST*/);
@@ -12780,21 +12781,22 @@ Multiple Module Templates:
 
         InstModule ms2m (/*AUTOINST*/
             // Outputs
-            .ptl_mapvalidx              (ptl_mapvalid[2]/*[3:0].[2]*/));
+            .ptl_mapvalidx      (ptl_mapvalid[2]/*[3:0].[2]*/));
         InstModule ms0m (/*AUTOINST*/
             // Outputs
-            .ptl_mapvalidx              (ptl_mapvalid[0]/*[3:0].[0]*/));
+            .ptl_mapvalidx      (ptl_mapvalid[0]/*[3:0].[0]*/));
 
-  and AUTOWIRE will declare \"wire [3:0] ptl_mapvalid [0:2];\".  The
-  indexes must be numeric for AUTOWIRE to combine them; overlapping or
-  duplicate indexes merge silently into the covering range.
+  and AUTOWIRE will declare \"wire [3:0] ptl_mapvalid [0:2];\".
+  The indexes must be numeric for AUTOWIRE to combine them;
+  overlapping or duplicate indexes merge silently into the
+  covering range.
 
   Alternatively, using a regular expression for @:
 
         /* InstModule AUTO_TEMPLATE \"_\\([a-z]+\\)\" (
-                .ptl_mapvalidx          (@_ptl_mapvalid),
-                .ptl_mapvalidp1x        (ptl_mapvalid_@),
-                );
+            .ptl_mapvalidx      (@_ptl_mapvalid),
+            .ptl_mapvalidp1x    (ptl_mapvalid_@),
+            );
         */
         InstModule ms2_FOO (/*AUTOINST*/);
         InstModule ms2_BAR (/*AUTOINST*/);
@@ -12803,12 +12805,12 @@ Multiple Module Templates:
 
         InstModule ms2_FOO (/*AUTOINST*/
             // Outputs
-            .ptl_mapvalidx              (FOO_ptl_mapvalid),
-            .ptl_mapvalidp1x            (ptl_mapvalid_FOO));
+            .ptl_mapvalidx      (FOO_ptl_mapvalid),
+            .ptl_mapvalidp1x    (ptl_mapvalid_FOO));
         InstModule ms2_BAR (/*AUTOINST*/
             // Outputs
-            .ptl_mapvalidx              (BAR_ptl_mapvalid),
-            .ptl_mapvalidp1x            (ptl_mapvalid_BAR));
+            .ptl_mapvalidx      (BAR_ptl_mapvalid),
+            .ptl_mapvalidp1x    (ptl_mapvalid_BAR));
 
 
 Regexp Templates:
@@ -13261,7 +13263,7 @@ Limitations:
   in AUTO_TEMPLATEs.
 
   This does NOT work on memories or SystemVerilog .name connections,
-  declare those yourself.  
+  declare those yourself.
 
   Verilog mode will add \"Couldn't Merge\" comments to signals it cannot
   determine how to bus together.  This occurs when you have ports with

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -9005,10 +9005,12 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
   (let (combo
         buswarn
 	out-list
-	sig highbit lowbit		; Temp information about current signal
+	sig highbit lowbit mem		; Temp information about current signal
 	sv-name sv-highbit sv-lowbit	; Details about signal we are forming
 	sv-comment sv-memory sv-enum sv-signed sv-type sv-multidim sv-busstring
 	sv-modport
+	sv-mem-low sv-mem-high	; Bounds of mergeable unpacked numeric ranges
+	sv-mem-ranges		; Unpacked numeric ranges, used to detect overlap
 	bus)
     ;; Shove signals so duplicated signals will be adjacent
     (setq in-list (sort in-list #'verilog-signals-sort-compare))
@@ -9020,7 +9022,10 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 	      sv-highbit nil
 	      sv-busstring nil
 	      sv-comment (verilog-sig-comment sig)
-	      sv-memory  (verilog-sig-memory sig)
+	      sv-memory  nil
+	      sv-mem-low nil
+	      sv-mem-high nil
+	      sv-mem-ranges nil
 	      sv-enum    (verilog-sig-enum sig)
 	      sv-signed  (verilog-sig-signed sig)
 	      sv-type    (verilog-sig-type sig)
@@ -9048,6 +9053,38 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 	    (bus
 	     ;; String, probably something like `preproc:0
 	     (setq sv-busstring bus)))
+      ;; Extract unpacked-array details
+      (setq mem (verilog-sig-memory sig))
+      (cond ((and mem
+		  (string-match "^\\[\\([+-]?[0-9]+\\):\\([+-]?[0-9]+\\)\\]$" mem)
+		  (<= (string-to-number (match-string 1 mem))
+		      (string-to-number (match-string 2 mem))))
+	     ;; Merge ascending numeric ranges without expanding every
+	     ;; index.  Preserve the existing warning for overlapping
+	     ;; ranges from different ports or instances.
+	     ;; Descending ranges are left alone so existing declarations
+	     ;; keep their direction.
+	     (let ((lo (string-to-number (match-string 1 mem)))
+		   (hi (string-to-number (match-string 2 mem)))
+		   (ranges sv-mem-ranges)
+		   (overlap nil))
+	       (when sv-memory  ; Mixed with an unmergeable form
+		 (setq buswarn ", Couldn't Merge"))
+	       (while ranges
+		 (let ((range (car ranges)))
+		   (when (and (<= lo (cdr range))
+			      (<= (car range) hi))
+		     (setq overlap t)))
+		 (setq ranges (cdr ranges)))
+	       (when overlap
+		 (setq buswarn ", Couldn't Merge"))
+	       (setq sv-mem-ranges (cons (cons lo hi) sv-mem-ranges)
+		     sv-mem-low (if sv-mem-low (min lo sv-mem-low) lo)
+		     sv-mem-high (if sv-mem-high (max hi sv-mem-high) hi))))
+	    (mem
+	     (when sv-mem-ranges  ; Mixed with a mergeable numeric range
+	       (setq buswarn ", Couldn't Merge"))
+	     (setq sv-memory (or sv-memory mem))))
       ;; Peek ahead to next signal
       (setq in-list (cdr in-list))
       (setq sig (car in-list))
@@ -9061,8 +9098,7 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 			  sv-name bus))
 	       (setq buswarn ", Couldn't Merge"))
 	     (if (verilog-sig-comment sig) (setq combo ", ..."))
-	     (setq sv-memory (or sv-memory (verilog-sig-memory sig))
-		   sv-enum   (or sv-enum   (verilog-sig-enum sig))
+	     (setq sv-enum   (or sv-enum   (verilog-sig-enum sig))
 		   sv-signed (or sv-signed (verilog-sig-signed sig))
                    sv-type   (or sv-type   (verilog-sig-type sig))
                    sv-multidim (or sv-multidim (verilog-sig-multidim sig))
@@ -9078,7 +9114,19 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 				  (concat "[" (int-to-string sv-highbit) ":"
 					  (int-to-string sv-lowbit) "]")))
 			  (concat sv-comment combo buswarn)
-			  sv-memory sv-enum sv-signed sv-type sv-multidim sv-modport)
+			  (cond
+			   ;; If any range was not safely mergeable, retain that
+			   ;; original unpacked declaration rather than silently
+			   ;; changing its direction or expression.
+			   (sv-memory sv-memory)
+			   (sv-mem-ranges
+			    ;; Combined unpacked index span, ascending.
+			    (concat "["
+				    (int-to-string sv-mem-low)
+				    ":"
+				    (int-to-string sv-mem-high)
+				    "]")))
+			  sv-enum sv-signed sv-type sv-multidim sv-modport)
 			 out-list)
 		   sv-name nil))))
     ;;
@@ -9683,6 +9731,20 @@ Return an array of [outputs inouts inputs wire reg assign const gparam intf]."
 (defun verilog-read-sub-decls-expr (submoddecls par-values comment port expr)
   "For `verilog-read-sub-decls-line', parse a subexpression and add signals."
   ;;(message "vrsde: `%s'" expr)
+  ;; "sig[2]/*[6:0].[2]*/" is a connection of one unpacked-array element
+  ;; made by an AUTO_TEMPLATE "[].[index]", see `verilog-auto-inst-port'.
+  ;; Canonicalize it to "sig[6:0].[2:2]" so the executable index is parsed
+  ;; as an unpacked range below (single-element, mergeable by
+  ;; `verilog-signals-combine-bus'); non-numeric indexes keep ".[index]".
+  (when (string-match
+	 "^\\s-*\\(\\(?:[a-zA-Z_][a-zA-Z_0-9]*\\|\\\\[^ \t\n\f]+\\s-\\)\\)\\s-*\\[\\([^][]+\\)\\]\\s-*/\\*\\(\\(?:\\[[^][]+\\]\\)*\\)\\.\\[[^][]+\\]\\*/\\s-*$"
+	 expr)
+    (let ((idx (match-string 2 expr)))
+      (setq expr (concat (match-string 1 expr)
+			 (match-string 3 expr)
+			 ".[" idx
+			 (if (string-match "^[+-]?[0-9]+$" idx) (concat ":" idx) "")
+			 "]"))))
   ;; Replace special /*[....]*/ comments inserted by verilog-auto-inst-port
   (setq expr (verilog-string-replace-matches
               "/\\*\\(\\.?\\[\\([^*]+\\|[*][^/]\\)+\\]\\)\\*/" "\\1" nil nil expr))
@@ -12377,6 +12439,16 @@ If PAR-VALUES replace final strings with these parameter values."
               ""))
       ;; Replace @ and [] magic variables in final output
       (setq tpl-net (verilog-string-replace-matches "@" tpl-num nil nil tpl-net))
+      ;; "sig[].[idx]" connects one element of an unpacked array; keep only
+      ;; the unpacked index executable and put the ranges into a comment,
+      ;; e.g. "sig[].[2]" becomes "sig[2]/*[6:0].[2]*/".  AUTOWIRE etc
+      ;; parse the comment back, see `verilog-read-sub-decls-expr'.
+      (while (string-match "\\[\\]\\.\\(\\[[^][]+\\]\\)" tpl-net)
+	(setq tpl-net (replace-match
+		       (concat (match-string 1 tpl-net)
+			       "/*" vl-mbits vl-bits
+			       "." (match-string 1 tpl-net) "*/")
+		       t t tpl-net)))
       (setq tpl-net (verilog-string-replace-matches "\\[\\]\\[\\]" dflt-bits nil nil tpl-net))
       (setq tpl-net (verilog-string-replace-matches "\\[\\]" auto-inst-vector-tpl nil nil tpl-net)))
     ;; Insert it
@@ -12702,6 +12774,31 @@ Multiple Module Templates:
             .ptl_mapvalidp1x            (ptl_mapvalid[3]));
 
   Note the @ character was replaced with the 2 from \"ms2m\".
+
+  A connection of \"[].[@]\" connects one element of an unpacked array.
+  The \"[]\" port range is placed into a comment so the connection stays
+  legal Verilog, and AUTOWIRE will declare the net as an unpacked array
+  spanning all connected indexes:
+
+        /* InstModule AUTO_TEMPLATE (
+                .ptl_mapvalidx          (ptl_mapvalid[].[@]),
+                );
+        */
+        InstModule ms2m (/*AUTOINST*/);
+        InstModule ms0m (/*AUTOINST*/);
+
+  Typing \\[verilog-auto] will make this into:
+
+        InstModule ms2m (/*AUTOINST*/
+            // Outputs
+            .ptl_mapvalidx              (ptl_mapvalid[2]/*[3:0].[2]*/));
+        InstModule ms0m (/*AUTOINST*/
+            // Outputs
+            .ptl_mapvalidx              (ptl_mapvalid[0]/*[3:0].[0]*/));
+
+  and AUTOWIRE will declare \"wire [3:0] ptl_mapvalid [0:2];\".  The
+  indexes must be numeric for AUTOWIRE to combine them; connecting the
+  same index twice warns \"Couldn't Merge\" in the declaration comment.
 
   Alternatively, using a regular expression for @:
 
@@ -13175,7 +13272,10 @@ Limitations:
   in AUTO_TEMPLATEs.
 
   This does NOT work on memories or SystemVerilog .name connections,
-  declare those yourself.
+  declare those yourself.  However, unpacked arrays connected
+  element-by-element with an AUTO_TEMPLATE \"[].[index]\" connection
+  (see `verilog-auto-inst') are declared, combining the connected
+  indexes into one ascending range.
 
   Verilog mode will add \"Couldn't Merge\" comments to signals it cannot
   determine how to bus together.  This occurs when you have ports with

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -9103,8 +9103,7 @@ Duplicate signals are also removed.  For example A[2] and A[1] become A[2:1]."
 			  (concat sv-comment combo buswarn)
 			  (cond
 			   ;; If any range was not safely mergeable, retain that
-			   ;; original unpacked declaration rather than silently
-			   ;; changing its direction or expression.
+			   ;; original unpacked declaration
 			   (sv-memory sv-memory)
 			   (sv-mem-low
 			    ;; Combined unpacked index span, ascending.


### PR DESCRIPTION
## Summary

Add support for connecting one element of an unpacked array per instance
in an AUTO_TEMPLATE, and have AUTOWIRE/AUTOINPUT declare the net as an
unpacked array covering all connected indexes.

    module InstModule
      (
       output [3:0] ptl_mapvalidx
       );
    endmodule

    module top ();
       /*AUTOWIRE*/
       /*
        InstModule AUTO_TEMPLATE
        (
        .ptl_mapvalidx (ptl_mapvalid[].[@]),
        );
        */
       InstModule ms2m
         (/*AUTOINST*/);
       InstModule ms0m
         (/*AUTOINST*/);
    endmodule

expands it to:

    module top ();
       /*AUTOWIRE*/
       // Beginning of automatic wires (for undeclared instantiated-module outputs)
       wire [3:0] ptl_mapvalid [0:2];   // From ms2m of InstModule.v, ...
       // End of automatics
       /*
        InstModule AUTO_TEMPLATE
        (
        .ptl_mapvalidx (ptl_mapvalid[].[@]),
        );
        */
       InstModule ms2m
         (/*AUTOINST*/
          // Outputs
          .ptl_mapvalidx                (ptl_mapvalid[2]/*[3:0].[2]*/)); // Templated
       InstModule ms0m
         (/*AUTOINST*/
          // Outputs
          .ptl_mapvalidx                (ptl_mapvalid[0]/*[3:0].[0]*/)); // Templated
    endmodule

## Implementation

- `verilog-auto-inst-port`: rewrite `sig[].[idx]` so only the unpacked
  index stays executable; the port ranges go into a `/*[bits].[idx]*/`
  comment (extending the existing comment convention used for memory
  ports), keeping the connection legal Verilog.
- `verilog-read-sub-decls-expr`: canonicalize the comment back into an
  unpacked range so AUTOWIRE and friends can parse it; numeric indexes
  become single-element ranges (`[2:2]`), non-numeric indexes pass
  through unchanged.
- `verilog-signals-combine-bus`: merge ascending numeric unpacked ranges
  via min/max into one covering range, the same way packed bits are
  merged.  Overlapping or duplicate ranges merge silently — an
  unpacked-array net fanned out to several instances must not warn.
  ", Couldn't Merge" is kept only when a numeric range mixes with an
  unmergeable form (descending like `[3:0]`, or symbolic like `[IDX]`),
  in which case the first unmergeable form wins so existing declarations
  keep their direction/expression.
- `[].[@]` on an instance whose name provides no value for `@` now
  raises an error instead of silently emitting a nonsense connection.

## Tests

- `tests/autoinst_tpl_array_index.v`: basic expansion, duplicate element
  index (merges to a single-element range), non-numeric index.
- `tests/tpl_arr_edge.v`: non-consecutive indexes, descending packed +
  ascending unpacked, multiple ports per template, mixed
  mergeable/unmergeable forms, hard-coded index gaps, single instance,
  descending instance order, overlapping ranges, signed ranges,
  descending-vs-numeric and symbolic-vs-numeric conflicts, negative
  single index, escaped identifiers, and a fanout regression test
  (unpacked-array input feeding two instances stays warning-free in
  AUTOINPUT).