### PR TITLE
Fix AUTO range simplification emitting illegal "+-" constants (#1879).

### DIFF
--- a/tests/autowire_merge_pm.v
+++ b/tests/autowire_merge_pm.v
@@ -18,6 +18,9 @@ endmodule
 
 module A
   (
-   output [DW-1+2:0] SIG_NAMEA
+   output [DW-1+2:0] SIG_NAMEA,
+   output [DW+1-2:0] SIG_NAMEB,
+   output [DW-3+1:0] SIG_NAMEC,
+   output [DW-1+1:0] SIG_NAMED
    );
 endmodule

--- a/tests_ok/autowire_merge_pm.v
+++ b/tests_ok/autowire_merge_pm.v
@@ -4,7 +4,10 @@ module TOP
   (
    /*AUTOOUTPUT*/
    // Beginning of automatic outputs (from unused autoinst outputs)
-   output [DW+1:0] SIG_NAMEA // From A of A.v
+   output [DW+1:0] SIG_NAMEA, // From A of A.v
+   output [DW-1:0] SIG_NAMEB, // From A of A.v
+   output [DW-2:0] SIG_NAMEC, // From A of A.v
+   output [DW-0:0] SIG_NAMED  // From A of A.v
    // End of automatics
    /*AUTOINPUT*/
    );
@@ -12,12 +15,18 @@ module TOP
    
    A A(/*AUTOINST*/
        // Outputs
-       .SIG_NAMEA                       (SIG_NAMEA[DW-1+2:0]));
+       .SIG_NAMEA                       (SIG_NAMEA[DW-1+2:0]),
+       .SIG_NAMEB                       (SIG_NAMEB[DW+1-2:0]),
+       .SIG_NAMEC                       (SIG_NAMEC[DW-3+1:0]),
+       .SIG_NAMED                       (SIG_NAMED[DW-1+1:0]));
    
 endmodule
 
 module A
   (
-   output [DW-1+2:0] SIG_NAMEA
+   output [DW-1+2:0] SIG_NAMEA,
+   output [DW+1-2:0] SIG_NAMEB,
+   output [DW-3+1:0] SIG_NAMEC,
+   output [DW-1+1:0] SIG_NAMED
    );
 endmodule

--- a/verilog-mode.el
+++ b/verilog-mode.el
@@ -11505,23 +11505,36 @@ This repairs those mis-inserted by an AUTOARG."
                   (op (match-string 3 out))
                   (rhs (string-to-number (match-string 4 out)))
                   (post (match-string 5 out))
-                  val)
+                  val prefix)
               (when (equal pre "-")
                 (setq lhs (- lhs)))
               (setq val (if (equal op "-")
                             (- lhs rhs)
-                          (+ lhs rhs))
-                    out (replace-match
-                         (concat (cond ((and (equal pre "-")
-                                             (< val 0))
-                                        "")  ; Not "--20" but just "-20"
-                                       ((and (equal pre "-")
-                                             (> val 0))
-                                        "+")  ; Not "-+20" but just "+20"
-                                       (t pre))
-                                 (int-to-string val)
-                                 post)
-                         nil nil out)) ))
+                          (+ lhs rhs)))
+              ;; Pick the printed prefix so two sign characters never adjoin
+              ;; (no "++", "+-", "--", "-+").  A sign in PRE was already
+              ;; absorbed into LHS above, so VAL carries the whole sum: for a
+              ;; negative result drop a sign PRE (int-to-string supplies the
+              ;; "-"), and for a positive result a PRE of "-" must flip to
+              ;; "+" (FOO-1+2 is FOO+1).  A non-sign PRE (such as "(", "[",
+              ;; ":") is kept verbatim.  For a zero result we keep PRE
+              ;; unchanged to preserve the long-standing "+0"/"-0" residual
+              ;; behaviour documented in the test cases below.
+              (setq prefix
+                    (cond
+                     ((< val 0)
+                      (if (or (equal pre "+") (equal pre "-"))
+                          ""                          ; val carries "-"
+                        pre))
+                     ((> val 0)
+                      (if (equal pre "-")
+                          "+"                       ; FOO-1+2 is FOO+1
+                        pre))
+                     (t                            ; val == 0: keep old "+0"/"-0"
+                      pre)))
+              (setq out (replace-match
+                         (concat prefix (int-to-string val) post)
+                         nil nil out))))
           ;; Next precedence is >>,<<
           (while (string-match
                   (concat "\\([[({:]\\)"  ;; No << as not transitive
@@ -11554,7 +11567,8 @@ This repairs those mis-inserted by an AUTOARG."
 ;;(verilog-simplify-range-expression "[(FOO*4+1-1)]")  ; "[FOO*4+0]"
 ;;(verilog-simplify-range-expression "[(func(BAR))]")  ; "[func(BAR)]"
 ;;(verilog-simplify-range-expression "[FOO-1+1-1+1]")  ; "[FOO-0]"
-;;(verilog-simplify-range-expression "[FOO-1+2:LSB-3+1]")  ; "[FOO+1:LSB-1]"
+;;(verilog-simplify-range-expression "[FOO-1+2:LSB-3+1]")  ; "[FOO+1:LSB-2]"
+;;(verilog-simplify-range-expression "[FOO+1-2:0]")  ; "[FOO-1:0]"
 ;;(verilog-simplify-range-expression "[$clog2(2)]")  ; "[1]"
 ;;(verilog-simplify-range-expression "[$clog2(7)]")  ; "[3]"
 ;;(verilog-simplify-range-expression "[(TEST[1])-1:0]")  ; "[(TEST[1])-1:0]"


### PR DESCRIPTION
Folding "+N-M" with N<M, e.g. [DW+1-2:0], previously produced the illegal [DW+-1:0]: the leading "+" was kept in front of the negative value's own sign.  Absorb a "+" or "-" prefix when the folded result is negative; a "-" prefix with a positive result still flips to "+" (FOO-1+2 is FOO+1), and the "+0"/"-0" residual forms are unchanged.

Extend the issue #1879 test to cover all four sign/result cases.

